### PR TITLE
Support API version 2026-02-06

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ This repository is an alternative Azure Storage SDK for Go; which supports for:
 At this time we support the following API Versions:
 
 * `2020-08-04` (`./storage/2020-08-04`)
+* `2023-11-03` (`./storage/2023-11-03`)
+* `2026-02-06` (`./storage/2026-02-06`)
 
 We're also open to supporting other versions of the Azure Storage APIs as necessary.
 

--- a/storage/2026-02-06/README.md
+++ b/storage/2026-02-06/README.md
@@ -1,0 +1,31 @@
+# Storage API Version 2026-02-06
+
+The following APIs are supported by this SDK - more information about each SDK can be found within the README in each package.
+
+## Blob Storage
+
+- [Blobs API](blob/blobs)
+- [Containers API](blob/containers)
+- [Accounts API](blob/accounts)
+
+## DataLakeStore Gen2
+
+- [FileSystems API](datalakestore/filesystems)
+- [Paths API](datalakestore/paths)
+
+## File Storage
+
+- [Directories API](file/directories)
+- [Files API](file/files)
+- [Shares API](file/shares)
+
+## Queue Storage
+
+- [Queues API](queue/queues)
+- [Messages API](queue/messages)
+
+## Table Storage
+
+- [Entities API](table/entities)
+- [Tables API](table/tables)
+

--- a/storage/2026-02-06/blob/accounts/README.md
+++ b/storage/2026-02-06/blob/accounts/README.md
@@ -1,0 +1,56 @@
+## Blob Storage Account SDK for API version 2026-02-06
+
+This package allows you to interact with the Accounts Blob Storage API
+
+### Supported Authorizers
+
+* Azure Active Directory 
+
+### Example Usage
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+	
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+func Example() error {
+	accountName := "storageaccount1"
+    
+    // e.g. https://github.com/jackofallops/giovanni/blob/76f5f686c99ecdcc3fa533a0330d0e1aacb1c327/example/azuread-auth/main.go#L54
+    client, err := buildClient()
+    if err != nil {
+    	return fmt.Errorf("error building client: %s", err)
+    }
+    
+    ctx := context.TODO()
+    
+    input := StorageServiceProperties{
+        StaticWebsite: &StaticWebsite{
+            Enabled:              true,
+            IndexDocument:        index,
+            ErrorDocument404Path: errorDocument,
+        },
+    }
+    
+    _, err = client.SetServiceProperties(ctx, accountName, input)
+    if err != nil {
+        return fmt.Errorf("error setting properties: %s", err)
+    }
+    
+    time.Sleep(2 * time.Second)
+    
+    _, err = accountsClient.GetServiceProperties(ctx, accountName)
+    if err != nil {
+        return fmt.Errorf("error getting properties: %s", err)
+    }
+    
+    return nil 
+}
+
+```

--- a/storage/2026-02-06/blob/accounts/client.go
+++ b/storage/2026-02-06/blob/accounts/client.go
@@ -1,0 +1,22 @@
+package accounts
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/dataplane/storage"
+)
+
+// Client is the base client for Blob Storage Blobs.
+type Client struct {
+	Client *storage.Client
+}
+
+func NewWithBaseUri(baseUri string) (*Client, error) {
+	baseClient, err := storage.NewStorageClient(baseUri, componentName, apiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("building base client: %+v", err)
+	}
+	return &Client{
+		Client: baseClient,
+	}, nil
+}

--- a/storage/2026-02-06/blob/accounts/get_service_properties.go
+++ b/storage/2026-02-06/blob/accounts/get_service_properties.go
@@ -1,0 +1,56 @@
+package accounts
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+)
+
+type GetServicePropertiesResult struct {
+	StorageServiceProperties
+	HttpResponse *http.Response
+}
+
+func (c Client) GetServiceProperties(ctx context.Context, accountName string) (result GetServicePropertiesResult, err error) {
+	if accountName == "" {
+		return result, fmt.Errorf("`accountName` cannot be an empty string")
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: servicePropertiesOptions{},
+		Path:          "/",
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			err = resp.Unmarshal(&result)
+			if err != nil {
+				err = fmt.Errorf("unmarshalling response: %+v", err)
+				return
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}

--- a/storage/2026-02-06/blob/accounts/models.go
+++ b/storage/2026-02-06/blob/accounts/models.go
@@ -1,0 +1,74 @@
+package accounts
+
+type StorageServiceProperties struct {
+	// Cors - Specifies CORS rules for the Blob service. You can include up to five CorsRule elements in the request. If no CorsRule elements are included in the request body, all CORS rules will be deleted, and CORS will be disabled for the Blob service.
+	Cors *CorsRules `xml:"Cors,omitempty"`
+	// DefaultServiceVersion - DefaultServiceVersion indicates the default version to use for requests to the Blob service if an incoming request’s version is not specified. Possible values include version 2008-10-27 and all more recent versions.
+	DefaultServiceVersion *string `xml:"DefaultServiceVersion,omitempty"`
+	// DeleteRetentionPolicy - The blob service properties for soft delete.
+	DeleteRetentionPolicy *DeleteRetentionPolicy `xml:"DeleteRetentionPolicy,omitempty"`
+	// Logging - The blob service properties for logging access
+	Logging *Logging `xml:"Logging,omitempty"`
+	// HourMetrics - The blob service properties for hour metrics
+	HourMetrics *MetricsConfig `xml:"HourMetrics,omitempty"`
+	// HourMetrics - The blob service properties for minute metrics
+	MinuteMetrics *MetricsConfig `xml:"MinuteMetrics,omitempty"`
+	// StaticWebsite - Optional
+	StaticWebsite *StaticWebsite `xml:"StaticWebsite,omitempty"`
+}
+
+// StaticWebsite sets the static website support properties on the Blob service.
+type StaticWebsite struct {
+	// Enabled - Required. Indicates whether static website support is enabled for the given account.
+	Enabled bool `xml:"Enabled"`
+	// IndexDocument - Optional. The webpage that Azure Storage serves for requests to the root of a website or any subfolder. For example, index.html. The value is case-sensitive.
+	IndexDocument string `xml:"IndexDocument,omitempty"`
+	// ErrorDocument404Path - Optional. The absolute path to a webpage that Azure Storage serves for requests that do not correspond to an existing file. For example, error/404.html. Only a single custom 404 page is supported in each static website. The value is case-sensitive.
+	ErrorDocument404Path string `xml:"ErrorDocument404Path,omitempty"`
+}
+
+// CorsRules sets the CORS rules. You can include up to five CorsRule elements in the request.
+type CorsRules struct {
+	// CorsRules - The List of CORS rules. You can include up to five CorsRule elements in the request.
+	CorsRules []CorsRule `xml:"CorsRules,omitempty"`
+}
+
+// DeleteRetentionPolicy the blob service properties for soft delete.
+type DeleteRetentionPolicy struct {
+	// Enabled - Indicates whether DeleteRetentionPolicy is enabled for the Blob service.
+	Enabled bool `xml:"Enabled,omitempty"`
+	// Days - Indicates the number of days that the deleted blob should be retained. The minimum specified value can be 1 and the maximum value can be 365.
+	Days int32 `xml:"Days,omitempty"`
+}
+
+// CorsRule specifies a CORS rule for the Blob service.
+type CorsRule struct {
+	// AllowedOrigins - Required if CorsRule element is present. A list of origin domains that will be allowed via CORS, or "" to allow all domains
+	AllowedOrigins []string `xml:"AllowedOrigins,omitempty"`
+	// AllowedMethods - Required if CorsRule element is present. A list of HTTP methods that are allowed to be executed by the origin.
+	AllowedMethods []string `xml:"AllowedMethods,omitempty"`
+	// MaxAgeInSeconds - Required if CorsRule element is present. The number of seconds that the client/browser should cache a preflight response.
+	MaxAgeInSeconds int32 `xml:"MaxAgeInSeconds,omitempty"`
+	// ExposedHeaders - Required if CorsRule element is present. A list of response headers to expose to CORS clients.
+	ExposedHeaders []string `xml:"ExposedHeaders,omitempty"`
+	// AllowedHeaders - Required if CorsRule element is present. A list of headers allowed to be part of the cross-origin request.
+	AllowedHeaders []string `xml:"AllowedHeaders,omitempty"`
+}
+
+// Logging specifies the access logging options for the Blob service.
+type Logging struct {
+	Version         string                `xml:"Version"`
+	Delete          bool                  `xml:"Delete"`
+	Read            bool                  `xml:"Read"`
+	Write           bool                  `xml:"Write"`
+	RetentionPolicy DeleteRetentionPolicy `xml:"RetentionPolicy"`
+}
+
+// MetricsConfig specifies the hour and/or minute metrics options for the Blob service.
+// Elements are all expected
+type MetricsConfig struct {
+	Version         string                `xml:"Version"`
+	Enabled         bool                  `xml:"Enabled"`
+	RetentionPolicy DeleteRetentionPolicy `xml:"RetentionPolicy"`
+	IncludeAPIs     bool                  `xml:"IncludeAPIs"`
+}

--- a/storage/2026-02-06/blob/accounts/resource_id.go
+++ b/storage/2026-02-06/blob/accounts/resource_id.go
@@ -1,0 +1,155 @@
+package accounts
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+)
+
+type SubDomainType string
+
+const (
+	BlobSubDomainType          SubDomainType = "blob"
+	DataLakeStoreSubDomainType SubDomainType = "dfs"
+	FileSubDomainType          SubDomainType = "file"
+	QueueSubDomainType         SubDomainType = "queue"
+	TableSubDomainType         SubDomainType = "table"
+)
+
+func PossibleValuesForSubDomainType() []SubDomainType {
+	return []SubDomainType{
+		BlobSubDomainType,
+		DataLakeStoreSubDomainType,
+		FileSubDomainType,
+		QueueSubDomainType,
+		TableSubDomainType,
+	}
+}
+
+// TODO: update this to implement `resourceids.ResourceId` once
+// https://github.com/hashicorp/go-azure-helpers/issues/187 is fixed
+var _ resourceids.Id = AccountId{}
+
+type AccountId struct {
+	AccountName   string
+	ZoneName      *string
+	SubDomainType SubDomainType
+	DomainSuffix  string
+	IsEdgeZone    bool
+}
+
+func (a AccountId) ID() string {
+	components := []string{
+		a.AccountName,
+	}
+	if a.IsEdgeZone {
+		// Storage Accounts hosted in an Edge Zone
+		//   `{accountname}.{component}.{edgezone}.edgestorage.azure.net`
+		components = append(components, string(a.SubDomainType))
+		if a.ZoneName != nil {
+			components = append(components, *a.ZoneName)
+		}
+	} else {
+		// Storage Accounts using a DNS Zone
+		//   `{accountname}.{dnszone}.{component}.storage.azure.net`
+		// or a Regular Storage Account
+		//   `{accountname}.{component}.core.windows.net`
+		if a.ZoneName != nil {
+			components = append(components, *a.ZoneName)
+		}
+		components = append(components, string(a.SubDomainType))
+	}
+	components = append(components, a.DomainSuffix)
+	return fmt.Sprintf("https://%s", strings.Join(components, "."))
+}
+
+func (a AccountId) String() string {
+	components := []string{
+		fmt.Sprintf("IsEdgeZone %t", a.IsEdgeZone),
+		fmt.Sprintf("ZoneName %q", pointer.From(a.ZoneName)),
+		fmt.Sprintf("Subdomain Type %q", string(a.SubDomainType)),
+		fmt.Sprintf("DomainSuffix %q", a.DomainSuffix),
+	}
+	return fmt.Sprintf("Account %q (%s)", a.AccountName, strings.Join(components, " / "))
+}
+
+func ParseAccountID(input, domainSuffix string) (*AccountId, error) {
+	uri, err := url.Parse(input)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q as a URL: %s", input, err)
+	}
+
+	if !strings.HasSuffix(uri.Host, domainSuffix) {
+		return nil, fmt.Errorf("expected the account %q to use a domain suffix of %q", uri.Host, domainSuffix)
+	}
+
+	// There's 3 different types of Storage Account ID:
+	// 1. Regular ol' Storage Accounts
+	//   `{name}.{component}.core.windows.net` (e.g. `example1.blob.core.windows.net`)
+	// 2. Storage Accounts using a DNS Zone
+	//   `{accountname}.{dnszone}.{component}.storage.azure.net`
+	// 3. Storage Accounts hosted in an Edge Zone
+	//   `{accountname}.{component}.{edgezone}.edgestorage.azure.net`
+	// since both `dnszone` and `edgezone` are the only two identifiers, we need to check if `domainSuffix` includes `edge`
+	// to know how to treat these
+
+	hostName := strings.TrimSuffix(uri.Host, fmt.Sprintf(".%s", domainSuffix))
+	components := strings.Split(hostName, ".")
+	accountId := AccountId{
+		DomainSuffix: domainSuffix,
+		IsEdgeZone:   strings.Contains(strings.ToLower(domainSuffix), "edge"),
+	}
+
+	if len(components) == 2 {
+		// this will be a regular Storage Account (e.g. `example1.blob.core.windows.net`)
+		accountId.AccountName = components[0]
+		subDomainType, err := parseSubDomainType(components[1])
+		if err != nil {
+			return nil, err
+		}
+		accountId.SubDomainType = *subDomainType
+		return &accountId, nil
+	}
+
+	if len(components) == 3 {
+		// This can either be a Zone'd Storage Account or a Storage Account within an Edge Zone
+		accountName := ""
+		subDomainTypeRaw := ""
+		zone := ""
+		if accountId.IsEdgeZone {
+			// `{accountname}.{component}.{edgezone}.edgestorage.azure.net`
+			accountName = components[0]
+			subDomainTypeRaw = components[1]
+			zone = components[2]
+		} else {
+			// `{accountname}.{dnszone}.{component}.storage.azure.net`
+			accountName = components[0]
+			zone = components[1]
+			subDomainTypeRaw = components[2]
+		}
+
+		accountId.AccountName = accountName
+		subDomainType, err := parseSubDomainType(subDomainTypeRaw)
+		if err != nil {
+			return nil, err
+		}
+		accountId.SubDomainType = *subDomainType
+		accountId.ZoneName = pointer.To(zone)
+		return &accountId, nil
+	}
+
+	return nil, fmt.Errorf("unknown storage account domain type %q", input)
+}
+
+func parseSubDomainType(input string) (*SubDomainType, error) {
+	for _, k := range PossibleValuesForSubDomainType() {
+		if strings.EqualFold(input, string(k)) {
+			return pointer.To(k), nil
+		}
+	}
+
+	return nil, fmt.Errorf("expected the subdomain type to be one of [%+v] but got %q", PossibleValuesForSubDomainType(), input)
+}

--- a/storage/2026-02-06/blob/accounts/resource_id_test.go
+++ b/storage/2026-02-06/blob/accounts/resource_id_test.go
@@ -1,0 +1,133 @@
+package accounts
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+)
+
+func TestParseAccountIDStandard(t *testing.T) {
+	input := "https://example.blob.core.windows.net"
+	expected := AccountId{
+		AccountName:   "example",
+		SubDomainType: BlobSubDomainType,
+		DomainSuffix:  "core.windows.net",
+	}
+	actual, err := ParseAccountID(input, "core.windows.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountName != expected.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountName, actual.AccountName)
+	}
+	if actual.SubDomainType != expected.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.SubDomainType, actual.SubDomainType)
+	}
+	if actual.DomainSuffix != expected.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.DomainSuffix, actual.DomainSuffix)
+	}
+}
+
+func TestParseAccountIDInDNSZone(t *testing.T) {
+	input := "https://example.zone.blob.storage.azure.net"
+	expected := AccountId{
+		AccountName:   "example",
+		ZoneName:      pointer.To("zone"),
+		SubDomainType: BlobSubDomainType,
+		DomainSuffix:  "storage.azure.net",
+	}
+	actual, err := ParseAccountID(input, "storage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountName != expected.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountName, actual.AccountName)
+	}
+	if actual.ZoneName == nil {
+		t.Fatalf("expected ZoneName to have a value but got nil")
+	}
+	if *actual.ZoneName != *expected.ZoneName {
+		t.Fatalf("expected ZoneName to be %q but got %q", *expected.ZoneName, *actual.ZoneName)
+	}
+	if actual.SubDomainType != expected.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.SubDomainType, actual.SubDomainType)
+	}
+	if actual.DomainSuffix != expected.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.DomainSuffix, actual.DomainSuffix)
+	}
+	if actual.IsEdgeZone {
+		t.Fatalf("expected IsEdgeZone to be false but got %t", actual.IsEdgeZone)
+	}
+}
+
+func TestParseAccountIDInEdgeZone(t *testing.T) {
+	input := "https://example.blob.danger.edgestorage.azure.net"
+	expected := AccountId{
+		AccountName:   "example",
+		ZoneName:      pointer.To("danger"),
+		IsEdgeZone:    true,
+		SubDomainType: BlobSubDomainType,
+		DomainSuffix:  "edgestorage.azure.net",
+	}
+	actual, err := ParseAccountID(input, "edgestorage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountName != expected.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountName, actual.AccountName)
+	}
+	if actual.ZoneName == nil {
+		t.Fatalf("expected ZoneName to have a value but got nil")
+	}
+	if *actual.ZoneName != *expected.ZoneName {
+		t.Fatalf("expected ZoneName to be %q but got %q", *expected.ZoneName, *actual.ZoneName)
+	}
+	if actual.SubDomainType != expected.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.SubDomainType, actual.SubDomainType)
+	}
+	if !actual.IsEdgeZone {
+		t.Fatalf("expected IsEdgeZone to be true but got %t", actual.IsEdgeZone)
+	}
+}
+
+func TestFormatAccountIDStandard(t *testing.T) {
+	actual := AccountId{
+		AccountName:   "example1",
+		ZoneName:      nil,
+		SubDomainType: FileSubDomainType,
+		DomainSuffix:  "core.windows.net",
+		IsEdgeZone:    false,
+	}.ID()
+	expected := "https://example1.file.core.windows.net"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatAccountIDInDNSZone(t *testing.T) {
+	actual := AccountId{
+		AccountName:   "example1",
+		ZoneName:      pointer.To("zone1"),
+		SubDomainType: FileSubDomainType,
+		DomainSuffix:  "storage.azure.net",
+		IsEdgeZone:    false,
+	}.ID()
+	expected := "https://example1.zone1.file.storage.azure.net"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatAccountIDInEdgeZone(t *testing.T) {
+	actual := AccountId{
+		AccountName:   "example1",
+		ZoneName:      pointer.To("zone1"),
+		SubDomainType: FileSubDomainType,
+		DomainSuffix:  "edgestorage.azure.net",
+		IsEdgeZone:    true,
+	}.ID()
+	expected := "https://example1.file.zone1.edgestorage.azure.net"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}

--- a/storage/2026-02-06/blob/accounts/service_properties_shared.go
+++ b/storage/2026-02-06/blob/accounts/service_properties_shared.go
@@ -1,0 +1,26 @@
+package accounts
+
+import (
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+var _ client.Options = servicePropertiesOptions{}
+
+type servicePropertiesOptions struct {
+}
+
+func (servicePropertiesOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (servicePropertiesOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (servicePropertiesOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "properties")
+	out.Append("restype", "service")
+	return out
+}

--- a/storage/2026-02-06/blob/accounts/set_service_properties.go
+++ b/storage/2026-02-06/blob/accounts/set_service_properties.go
@@ -1,0 +1,52 @@
+package accounts
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+)
+
+type SetServicePropertiesResult struct {
+	HttpResponse *http.Response
+}
+
+func (c Client) SetServiceProperties(ctx context.Context, accountName string, input StorageServiceProperties) (result SetServicePropertiesResult, err error) {
+	if accountName == "" {
+		return result, fmt.Errorf("`accountName` cannot be an empty string")
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+		},
+		HttpMethod:    http.MethodPut,
+		OptionsObject: servicePropertiesOptions{},
+		Path:          "/",
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	if err = req.Marshal(&input); err != nil {
+		err = fmt.Errorf("marshaling request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}

--- a/storage/2026-02-06/blob/accounts/set_service_properties_test.go
+++ b/storage/2026-02-06/blob/accounts/set_service_properties_test.go
@@ -1,0 +1,106 @@
+package accounts
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+func TestContainerLifecycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+
+	_, err = client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindStorageVTwo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+	accountsClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.blob.%s", accountName, *domainSuffix))
+	if err != nil {
+		t.Fatal(fmt.Errorf("building client for environment: %+v", err))
+	}
+	client.PrepareWithResourceManagerAuth(accountsClient.Client)
+
+	input := StorageServiceProperties{}
+	_, err = accountsClient.SetServiceProperties(ctx, accountName, input)
+	if err != nil {
+		t.Fatal(fmt.Errorf("error setting properties: %s", err))
+	}
+
+	var index = "index.html"
+	//var enabled = true
+	var errorDocument = "404.html"
+
+	input = StorageServiceProperties{
+		StaticWebsite: &StaticWebsite{
+			Enabled:              true,
+			IndexDocument:        index,
+			ErrorDocument404Path: errorDocument,
+		},
+		Logging: &Logging{
+			Version: "2.0",
+			Delete:  true,
+			Read:    true,
+			Write:   true,
+			RetentionPolicy: DeleteRetentionPolicy{
+				Enabled: true,
+				Days:    7,
+			},
+		},
+	}
+
+	_, err = accountsClient.SetServiceProperties(ctx, accountName, input)
+	if err != nil {
+		t.Fatal(fmt.Errorf("error setting properties: %s", err))
+	}
+
+	t.Log("[DEBUG] Waiting 2 seconds..")
+	time.Sleep(2 * time.Second)
+
+	result, err := accountsClient.GetServiceProperties(ctx, accountName)
+	if err != nil {
+		t.Fatal(fmt.Errorf("error getting properties: %s", err))
+	}
+
+	website := result.StaticWebsite
+	if website.Enabled != true {
+		t.Fatalf("Expected the StaticWebsite %t but got %t", true, website.Enabled)
+	}
+
+	logging := result.Logging
+	if logging.Version != "2.0" {
+		t.Fatalf("Expected the Logging Version %s but got %s", "2.0", logging.Version)
+	}
+	if !logging.Read {
+		t.Fatalf("Expected the Logging Read %t but got %t", true, logging.Read)
+	}
+	if !logging.Write {
+		t.Fatalf("Expected the Logging Write %t but got %t", true, logging.Write)
+	}
+	if !logging.Delete {
+		t.Fatalf("Expected the Logging Delete %t but got %t", true, logging.Delete)
+	}
+	if !logging.RetentionPolicy.Enabled {
+		t.Fatalf("Expected the Logging RetentionPolicy.Enabled %t but got %t", true, logging.RetentionPolicy.Enabled)
+	}
+	if logging.RetentionPolicy.Days != 7 {
+		t.Fatalf("Expected the Logging RetentionPolicy.Enabled %d but got %d", 7, logging.RetentionPolicy.Days)
+	}
+}

--- a/storage/2026-02-06/blob/accounts/version.go
+++ b/storage/2026-02-06/blob/accounts/version.go
@@ -1,0 +1,4 @@
+package accounts
+
+const apiVersion = "2026-02-06"
+const componentName = "blob/accounts"

--- a/storage/2026-02-06/blob/blobs/README.md
+++ b/storage/2026-02-06/blob/blobs/README.md
@@ -1,0 +1,54 @@
+## Blob Storage Blobs SDK for API version 2026-02-06
+
+This package allows you to interact with the Blobs Blob Storage API
+
+### Supported Authorizers
+
+* Azure Active Directory (for the Resource Endpoint `https://storage.azure.com`)
+* SharedKeyLite (Blob, File & Queue)
+
+### Example Usage
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+	
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/blobs"
+)
+
+func Example() error {
+	accountName := "storageaccount1"
+    storageAccountKey := "ABC123...."
+    containerName := "mycontainer"
+	domainSuffix := "core.windows.net"
+    fileName := "example-large-file.iso"
+
+	blobClient, err := blobs.NewWithBaseUri(fmt.Sprintf("https://%s.blob.%s", accountName, domainSuffix))
+	if err != nil {
+		return fmt.Errorf("building client for environment: %v", err)
+	}
+	
+	auth, err := auth.NewSharedKeyAuthorizer(accountName, storageAccountKey, auth.SharedKey)
+	if err != nil {
+		return fmt.Errorf("building SharedKey authorizer: %+v", err)
+	}
+	blobClient.Client.SetAuthorizer(auth)
+    
+    ctx := context.TODO()
+    copyInput := blobs.CopyInput{
+        CopySource: "http://releases.ubuntu.com/14.04/ubuntu-14.04.6-desktop-amd64.iso",
+    }
+    refreshInterval := 5 * time.Second
+    if err := blobClient.CopyAndWait(ctx, containerName, fileName, copyInput, refreshInterval); err != nil {
+        return fmt.Errorf("Error copying: %s", err)
+    }
+    
+    return nil 
+}
+
+```

--- a/storage/2026-02-06/blob/blobs/api.go
+++ b/storage/2026-02-06/blob/blobs/api.go
@@ -1,0 +1,41 @@
+package blobs
+
+import (
+	"context"
+	"os"
+)
+
+type StorageBlob interface {
+	AppendBlock(ctx context.Context, containerName string, blobName string, input AppendBlockInput) (AppendBlockResponse, error)
+	Copy(ctx context.Context, containerName string, blobName string, input CopyInput) (CopyResponse, error)
+	AbortCopy(ctx context.Context, containerName string, blobName string, input AbortCopyInput) (CopyAbortResponse, error)
+	CopyAndWait(ctx context.Context, containerName string, blobName string, input CopyInput) error
+	Delete(ctx context.Context, containerName string, blobName string, input DeleteInput) (DeleteResponse, error)
+	DeleteSnapshot(ctx context.Context, containerName string, blobName string, input DeleteSnapshotInput) (DeleteSnapshotResponse, error)
+	DeleteSnapshots(ctx context.Context, containerName string, blobName string, input DeleteSnapshotsInput) (DeleteSnapshotsResponse, error)
+	Get(ctx context.Context, containerName string, blobName string, input GetInput) (GetResponse, error)
+	GetBlockList(ctx context.Context, containerName string, blobName string, input GetBlockListInput) (GetBlockListResponse, error)
+	GetPageRanges(ctx context.Context, containerName, blobName string, input GetPageRangesInput) (GetPageRangesResponse, error)
+	IncrementalCopyBlob(ctx context.Context, containerName string, blobName string, input IncrementalCopyBlobInput) (IncrementalCopyBlob, error)
+	AcquireLease(ctx context.Context, containerName string, blobName string, input AcquireLeaseInput) (AcquireLeaseResponse, error)
+	BreakLease(ctx context.Context, containerName string, blobName string, input BreakLeaseInput) (BreakLeaseResponse, error)
+	ChangeLease(ctx context.Context, containerName string, blobName string, input ChangeLeaseInput) (ChangeLeaseResponse, error)
+	ReleaseLease(ctx context.Context, containerName string, blobName string, input ReleaseLeaseInput) (ReleaseLeaseResponse, error)
+	RenewLease(ctx context.Context, containerName string, blobName string, input RenewLeaseInput) (RenewLeaseResponse, error)
+	SetMetaData(ctx context.Context, containerName string, blobName string, input SetMetaDataInput) (SetMetaDataResponse, error)
+	GetProperties(ctx context.Context, containerName string, blobName string, input GetPropertiesInput) (GetPropertiesResponse, error)
+	SetProperties(ctx context.Context, containerName string, blobName string, input SetPropertiesInput) (SetPropertiesResponse, error)
+	PutAppendBlob(ctx context.Context, containerName string, blobName string, input PutAppendBlobInput) (PutAppendBlobResponse, error)
+	PutBlock(ctx context.Context, containerName string, blobName string, input PutBlockInput) (PutBlockResponse, error)
+	PutBlockBlob(ctx context.Context, containerName string, blobName string, input PutBlockBlobInput) (PutBlockBlobResponse, error)
+	PutBlockBlobFromFile(ctx context.Context, containerName string, blobName string, file *os.File, input PutBlockBlobInput) error
+	PutBlockList(ctx context.Context, containerName string, blobName string, input PutBlockListInput) (PutBlockListResponse, error)
+	PutBlockFromURL(ctx context.Context, containerName string, blobName string, input PutBlockFromURLInput) (PutBlockFromURLResponse, error)
+	PutPageBlob(ctx context.Context, containerName string, blobName string, input PutPageBlobInput) (PutPageBlobResponse, error)
+	PutPageClear(ctx context.Context, containerName string, blobName string, input PutPageClearInput) (PutPageClearResponse, error)
+	PutPageUpdate(ctx context.Context, containerName string, blobName string, input PutPageUpdateInput) (PutPageUpdateResponse, error)
+	SetTier(ctx context.Context, containerName string, blobName string, input SetTierInput) (SetTierResponse, error)
+	Snapshot(ctx context.Context, containerName string, blobName string, input SnapshotInput) (SnapshotResponse, error)
+	GetSnapshotProperties(ctx context.Context, containerName string, blobName string, input GetSnapshotPropertiesInput) (GetPropertiesResponse, error)
+	Undelete(ctx context.Context, containerName string, blobName string) (UndeleteResponse, error)
+}

--- a/storage/2026-02-06/blob/blobs/append_block.go
+++ b/storage/2026-02-06/blob/blobs/append_block.go
@@ -1,0 +1,169 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type AppendBlockInput struct {
+	// A number indicating the byte offset to compare.
+	// Append Block will succeed only if the append position is equal to this number.
+	// If it is not, the request will fail with an AppendPositionConditionNotMet
+	// error (HTTP status code 412 – Precondition Failed)
+	BlobConditionAppendPosition *int64
+
+	// The max length in bytes permitted for the append blob.
+	// If the Append Block operation would cause the blob to exceed that limit or if the blob size
+	// is already greater than the value specified in this header, the request will fail with
+	// an MaxBlobSizeConditionNotMet error (HTTP status code 412 – Precondition Failed).
+	BlobConditionMaxSize *int64
+
+	// The Bytes which should be appended to the end of this Append Blob.
+	// This can either be nil, which creates an empty blob, or a byte array
+	Content *[]byte
+
+	// An MD5 hash of the block content.
+	// This hash is used to verify the integrity of the block during transport.
+	// When this header is specified, the storage service compares the hash of the content
+	// that has arrived with this header value.
+	//
+	// Note that this MD5 hash is not stored with the blob.
+	// If the two hashes do not match, the operation will fail with error code 400 (Bad Request).
+	ContentMD5 *string
+
+	// Required if the blob has an active lease.
+	// To perform this operation on a blob with an active lease, specify the valid lease ID for this header.
+	LeaseID *string
+
+	// The encryption scope to set for the request content.
+	EncryptionScope *string
+}
+
+type AppendBlockResponse struct {
+	HttpResponse *http.Response
+
+	BlobAppendOffset        string
+	BlobCommittedBlockCount int64
+	ContentMD5              string
+	ETag                    string
+	LastModified            string
+}
+
+// AppendBlock commits a new block of data to the end of an existing append blob.
+func (c Client) AppendBlock(ctx context.Context, containerName, blobName string, input AppendBlockInput) (result AppendBlockResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	if input.Content != nil && len(*input.Content) > (4*1024*1024) {
+		err = fmt.Errorf("`input.Content` must be at most 4MB")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: appendBlockOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	err = req.Marshal(input.Content)
+	if err != nil {
+		err = fmt.Errorf("marshalling request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.BlobAppendOffset = resp.Header.Get("x-ms-blob-append-offset")
+				result.ContentMD5 = resp.Header.Get("Content-MD5")
+				result.ETag = resp.Header.Get("ETag")
+				result.LastModified = resp.Header.Get("Last-Modified")
+
+				if v := resp.Header.Get("x-ms-blob-committed-block-count"); v != "" {
+					i, innerErr := strconv.Atoi(v)
+					if innerErr != nil {
+						err = fmt.Errorf("parsing `x-ms-blob-committed-block-count` header value %q: %+v", v, innerErr)
+						return
+					}
+					result.BlobCommittedBlockCount = int64(i)
+				}
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type appendBlockOptions struct {
+	input AppendBlockInput
+}
+
+func (a appendBlockOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	if a.input.BlobConditionAppendPosition != nil {
+		headers.Append("x-ms-blob-condition-appendpos", strconv.Itoa(int(*a.input.BlobConditionAppendPosition)))
+	}
+	if a.input.BlobConditionMaxSize != nil {
+		headers.Append("x-ms-blob-condition-maxsize", strconv.Itoa(int(*a.input.BlobConditionMaxSize)))
+	}
+	if a.input.ContentMD5 != nil {
+		headers.Append("x-ms-blob-content-md5", *a.input.ContentMD5)
+	}
+	if a.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *a.input.LeaseID)
+	}
+	if a.input.EncryptionScope != nil {
+		headers.Append("x-ms-encryption-scope", *a.input.EncryptionScope)
+	}
+	if a.input.Content != nil {
+		headers.Append("Content-Length", strconv.Itoa(len(*a.input.Content)))
+	}
+	return headers
+}
+
+func (a appendBlockOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (a appendBlockOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "appendblock")
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/blob_append_test.go
+++ b/storage/2026-02-06/blob/blobs/blob_append_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
-	"github.com/jackofallops/giovanni/storage/2020-08-04/blob/containers"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/containers"
 	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
 )
 

--- a/storage/2026-02-06/blob/blobs/blob_append_test.go
+++ b/storage/2026-02-06/blob/blobs/blob_append_test.go
@@ -1,0 +1,174 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2020-08-04/blob/containers"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+func TestAppendBlobLifecycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	containerName := fmt.Sprintf("cont-%d", testhelpers.RandomInt())
+	fileName := "append-blob.txt"
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindBlobStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+
+	containersClient, err := containers.NewWithBaseUri(fmt.Sprintf("https://%s.blob.%s", testData.StorageAccountName, *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err := client.PrepareWithSharedKeyAuth(containersClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	_, err = containersClient.Create(ctx, containerName, containers.CreateInput{})
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error creating: %s", err))
+	}
+	defer containersClient.Delete(ctx, containerName)
+
+	blobClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.blob.%s", testData.StorageAccountName, *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err := client.PrepareWithSharedKeyAuth(blobClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	t.Logf("[DEBUG] Putting Append Blob..")
+	if _, err := blobClient.PutAppendBlob(ctx, containerName, fileName, PutAppendBlobInput{}); err != nil {
+		t.Fatalf("Error putting append blob: %s", err)
+	}
+
+	t.Logf("[DEBUG] Retrieving Properties..")
+	props, err := blobClient.GetProperties(ctx, containerName, fileName, GetPropertiesInput{})
+	if err != nil {
+		t.Fatalf("Error retrieving properties: %s", err)
+	}
+	if props.ContentLength != 0 {
+		t.Fatalf("Expected Content-Length to be 0 but it was %d", props.ContentLength)
+	}
+
+	t.Logf("[DEBUG] Appending First Block..")
+	appendInput := AppendBlockInput{
+		Content: &[]byte{
+			12,
+			48,
+			93,
+			76,
+			29,
+			10,
+		},
+	}
+	if _, err := blobClient.AppendBlock(ctx, containerName, fileName, appendInput); err != nil {
+		t.Fatalf("Error appending first block: %s", err)
+	}
+
+	t.Logf("[DEBUG] Re-Retrieving Properties..")
+	props, err = blobClient.GetProperties(ctx, containerName, fileName, GetPropertiesInput{})
+	if err != nil {
+		t.Fatalf("Error retrieving properties: %s", err)
+	}
+	if props.ContentLength != 6 {
+		t.Fatalf("Expected Content-Length to be 6 but it was %d", props.ContentLength)
+	}
+
+	t.Logf("[DEBUG] Appending Second Block..")
+	appendInput = AppendBlockInput{
+		Content: &[]byte{
+			92,
+			62,
+			64,
+			47,
+			83,
+			77,
+		},
+	}
+	if _, err := blobClient.AppendBlock(ctx, containerName, fileName, appendInput); err != nil {
+		t.Fatalf("Error appending Second block: %s", err)
+	}
+
+	t.Logf("[DEBUG] Re-Retrieving Properties..")
+	props, err = blobClient.GetProperties(ctx, containerName, fileName, GetPropertiesInput{})
+	if err != nil {
+		t.Fatalf("Error retrieving properties: %s", err)
+	}
+	if props.ContentLength != 12 {
+		t.Fatalf("Expected Content-Length to be 12 but it was %d", props.ContentLength)
+	}
+
+	t.Logf("[DEBUG] Acquiring Lease..")
+	leaseDetails, err := blobClient.AcquireLease(ctx, containerName, fileName, AcquireLeaseInput{
+		LeaseDuration: -1,
+	})
+	if err != nil {
+		t.Fatalf("Error acquiring Lease: %s", err)
+	}
+	t.Logf("[DEBUG] Lease ID is %q", leaseDetails.LeaseID)
+
+	t.Logf("[DEBUG] Appending Third Block..")
+	appendInput = AppendBlockInput{
+		Content: &[]byte{
+			64,
+			35,
+			28,
+			93,
+			11,
+			23,
+		},
+		LeaseID: &leaseDetails.LeaseID,
+	}
+	if _, err := blobClient.AppendBlock(ctx, containerName, fileName, appendInput); err != nil {
+		t.Fatalf("Error appending Third block: %s", err)
+	}
+
+	t.Logf("[DEBUG] Re-Retrieving Properties..")
+	props, err = blobClient.GetProperties(ctx, containerName, fileName, GetPropertiesInput{
+		LeaseID: &leaseDetails.LeaseID,
+	})
+	if err != nil {
+		t.Fatalf("Error retrieving properties: %s", err)
+	}
+	if props.ContentLength != 18 {
+		t.Fatalf("Expected Content-Length to be 18 but it was %d", props.ContentLength)
+	}
+
+	t.Logf("[DEBUG] Breaking Lease..")
+	breakLeaseInput := BreakLeaseInput{
+		LeaseID: leaseDetails.LeaseID,
+	}
+	if _, err := blobClient.BreakLease(ctx, containerName, fileName, breakLeaseInput); err != nil {
+		t.Fatalf("Error breaking lease: %s", err)
+	}
+
+	t.Logf("[DEBUG] Deleting Lease..")
+	if _, err := blobClient.Delete(ctx, containerName, fileName, DeleteInput{}); err != nil {
+		t.Fatalf("Error deleting: %s", err)
+	}
+}

--- a/storage/2026-02-06/blob/blobs/blob_page_test.go
+++ b/storage/2026-02-06/blob/blobs/blob_page_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
-	"github.com/jackofallops/giovanni/storage/2020-08-04/blob/containers"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/containers"
 	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
 )
 

--- a/storage/2026-02-06/blob/blobs/blob_page_test.go
+++ b/storage/2026-02-06/blob/blobs/blob_page_test.go
@@ -1,0 +1,108 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2020-08-04/blob/containers"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+func TestPageBlobLifecycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	containerName := fmt.Sprintf("cont-%d", testhelpers.RandomInt())
+	fileName := "append-blob.txt"
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindStorageVTwo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+
+	containersClient, err := containers.NewWithBaseUri(fmt.Sprintf("https://%s.blob.%s", testData.StorageAccountName, *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err = client.PrepareWithSharedKeyAuth(containersClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	_, err = containersClient.Create(ctx, containerName, containers.CreateInput{})
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error creating: %s", err))
+	}
+	defer containersClient.Delete(ctx, containerName)
+
+	blobClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.blob.%s", testData.StorageAccountName, *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err = client.PrepareWithSharedKeyAuth(blobClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	t.Logf("[DEBUG] Putting Page Blob..")
+	fileSize := int64(10240000)
+	if _, err := blobClient.PutPageBlob(ctx, containerName, fileName, PutPageBlobInput{
+		BlobContentLengthBytes: fileSize,
+	}); err != nil {
+		t.Fatalf("Error putting page blob: %s", err)
+	}
+
+	t.Logf("[DEBUG] Retrieving Properties..")
+	props, err := blobClient.GetProperties(ctx, containerName, fileName, GetPropertiesInput{})
+	if err != nil {
+		t.Fatalf("Error retrieving properties: %s", err)
+	}
+	if props.ContentLength != fileSize {
+		t.Fatalf("Expected Content-Length to be %d but it was %d", fileSize, props.ContentLength)
+	}
+
+	for iteration := 1; iteration <= 3; iteration++ {
+		t.Logf("[DEBUG] Putting Page %d of 3..", iteration)
+		byteArray := func() []byte {
+			o := make([]byte, 0)
+
+			for i := 0; i < 512; i++ {
+				o = append(o, byte(i))
+			}
+
+			return o
+		}()
+		startByte := int64(512 * iteration)
+		endByte := int64(startByte + 511)
+		putPageInput := PutPageUpdateInput{
+			StartByte: startByte,
+			EndByte:   endByte,
+			Content:   byteArray,
+		}
+		if _, err := blobClient.PutPageUpdate(ctx, containerName, fileName, putPageInput); err != nil {
+			t.Fatalf("Error putting page: %s", err)
+		}
+	}
+
+	t.Logf("[DEBUG] Deleting..")
+	if _, err := blobClient.Delete(ctx, containerName, fileName, DeleteInput{}); err != nil {
+		t.Fatalf("Error deleting: %s", err)
+	}
+}

--- a/storage/2026-02-06/blob/blobs/client.go
+++ b/storage/2026-02-06/blob/blobs/client.go
@@ -1,0 +1,22 @@
+package blobs
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/dataplane/storage"
+)
+
+// Client is the base client for Blob Storage Blobs.
+type Client struct {
+	Client *storage.Client
+}
+
+func NewWithBaseUri(baseUri string) (*Client, error) {
+	baseClient, err := storage.NewStorageClient(baseUri, componentName, apiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("building base client: %+v", err)
+	}
+	return &Client{
+		Client: baseClient,
+	}, nil
+}

--- a/storage/2026-02-06/blob/blobs/copy.go
+++ b/storage/2026-02-06/blob/blobs/copy.go
@@ -1,0 +1,240 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type CopyInput struct {
+	// Specifies the name of the source blob or file.
+	// Beginning with version 2012-02-12, this value may be a URL of up to 2 KB in length that specifies a blob.
+	// The value should be URL-encoded as it would appear in a request URI.
+	// A source blob in the same storage account can be authenticated via Shared Key.
+	// However, if the source is a blob in another account,
+	// the source blob must either be public or must be authenticated via a shared access signature.
+	// If the source blob is public, no authentication is required to perform the copy operation.
+	//
+	// Beginning with version 2015-02-21, the source object may be a file in the Azure File service.
+	// If the source object is a file that is to be copied to a blob, then the source file must be authenticated
+	// using a shared access signature, whether it resides in the same account or in a different account.
+	//
+	// Only storage accounts created on or after June 7th, 2012 allow the Copy Blob operation to
+	// copy from another storage account.
+	CopySource string
+
+	// The ID of the Lease
+	// Required if the destination blob has an active lease.
+	// The lease ID specified for this header must match the lease ID of the destination blob.
+	// If the request does not include the lease ID or it is not valid,
+	// the operation fails with status code 412 (Precondition Failed).
+	//
+	// If this header is specified and the destination blob does not currently have an active lease,
+	// the operation will also fail with status code 412 (Precondition Failed).
+	LeaseID *string
+
+	// The ID of the Lease on the Source Blob
+	// Specify to perform the Copy Blob operation only if the lease ID matches the active lease ID of the source blob.
+	SourceLeaseID *string
+
+	// For page blobs on a premium account only. Specifies the tier to be set on the target blob
+	AccessTier *AccessTier
+
+	// A user-defined name-value pair associated with the blob.
+	// If no name-value pairs are specified, the operation will copy the metadata from the source blob or
+	// file to the destination blob.
+	// If one or more name-value pairs are specified, the destination blob is created with the specified metadata,
+	// and metadata is not copied from the source blob or file.
+	MetaData map[string]string
+
+	// An ETag value.
+	// Specify an ETag value for this conditional header to copy the blob only if the specified
+	// ETag value matches the ETag value for an existing destination blob.
+	// If the ETag for the destination blob does not match the ETag specified for If-Match,
+	// the Blob service returns status code 412 (Precondition Failed).
+	IfMatch *string
+
+	// An ETag value, or the wildcard character (*).
+	// Specify an ETag value for this conditional header to copy the blob only if the specified
+	// ETag value does not match the ETag value for the destination blob.
+	// Specify the wildcard character (*) to perform the operation only if the destination blob does not exist.
+	// If the specified condition isn't met, the Blob service returns status code 412 (Precondition Failed).
+	IfNoneMatch *string
+
+	// A DateTime value.
+	// Specify this conditional header to copy the blob only if the destination blob
+	// has been modified since the specified date/time.
+	// If the destination blob has not been modified, the Blob service returns status code 412 (Precondition Failed).
+	IfModifiedSince *string
+
+	// A DateTime value.
+	// Specify this conditional header to copy the blob only if the destination blob
+	// has not been modified since the specified date/time.
+	// If the destination blob has been modified, the Blob service returns status code 412 (Precondition Failed).
+	IfUnmodifiedSince *string
+
+	// An ETag value.
+	// Specify this conditional header to copy the source blob only if its ETag matches the value specified.
+	// If the ETag values do not match, the Blob service returns status code 412 (Precondition Failed).
+	// This cannot be specified if the source is an Azure File.
+	SourceIfMatch *string
+
+	// An ETag value.
+	// Specify this conditional header to copy the blob only if its ETag does not match the value specified.
+	// If the values are identical, the Blob service returns status code 412 (Precondition Failed).
+	// This cannot be specified if the source is an Azure File.
+	SourceIfNoneMatch *string
+
+	// A DateTime value.
+	// Specify this conditional header to copy the blob only if the source blob has been modified
+	// since the specified date/time.
+	// If the source blob has not been modified, the Blob service returns status code 412 (Precondition Failed).
+	// This cannot be specified if the source is an Azure File.
+	SourceIfModifiedSince *string
+
+	// A DateTime value.
+	// Specify this conditional header to copy the blob only if the source blob has not been modified
+	// since the specified date/time.
+	// If the source blob has been modified, the Blob service returns status code 412 (Precondition Failed).
+	// This header cannot be specified if the source is an Azure File.
+	SourceIfUnmodifiedSince *string
+
+	// The encryption scope to set for the request content.
+	EncryptionScope *string
+}
+
+type CopyResponse struct {
+	HttpResponse *http.Response
+
+	CopyID     string
+	CopyStatus string
+}
+
+// Copy copies a blob to a destination within the storage account asynchronously.
+func (c Client) Copy(ctx context.Context, containerName, blobName string, input CopyInput) (result CopyResponse, err error) {
+	if containerName == "" {
+		return result, fmt.Errorf("`containerName` cannot be an empty string")
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		return result, fmt.Errorf("`containerName` must be a lower-cased string")
+	}
+
+	if blobName == "" {
+		return result, fmt.Errorf("`blobName` cannot be an empty string")
+	}
+
+	if input.CopySource == "" {
+		return result, fmt.Errorf("`input.CopySource` cannot be an empty string")
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: copyOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.CopyID = resp.Header.Get("x-ms-copy-id")
+				result.CopyStatus = resp.Header.Get("x-ms-copy-status")
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type copyOptions struct {
+	input CopyInput
+}
+
+func (c copyOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("x-ms-copy-source", c.input.CopySource)
+
+	if c.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *c.input.LeaseID)
+	}
+
+	if c.input.SourceLeaseID != nil {
+		headers.Append("x-ms-source-lease-id", *c.input.SourceLeaseID)
+	}
+
+	if c.input.AccessTier != nil {
+		headers.Append("x-ms-access-tier", string(*c.input.AccessTier))
+	}
+
+	if c.input.IfMatch != nil {
+		headers.Append("If-Match", *c.input.IfMatch)
+	}
+
+	if c.input.IfNoneMatch != nil {
+		headers.Append("If-None-Match", *c.input.IfNoneMatch)
+	}
+
+	if c.input.IfUnmodifiedSince != nil {
+		headers.Append("If-Unmodified-Since", *c.input.IfUnmodifiedSince)
+	}
+
+	if c.input.IfModifiedSince != nil {
+		headers.Append("If-Modified-Since", *c.input.IfModifiedSince)
+	}
+
+	if c.input.SourceIfMatch != nil {
+		headers.Append("x-ms-source-if-match", *c.input.SourceIfMatch)
+	}
+
+	if c.input.SourceIfNoneMatch != nil {
+		headers.Append("x-ms-source-if-none-match", *c.input.SourceIfNoneMatch)
+	}
+
+	if c.input.SourceIfModifiedSince != nil {
+		headers.Append("x-ms-source-if-modified-since", *c.input.SourceIfModifiedSince)
+	}
+
+	if c.input.SourceIfUnmodifiedSince != nil {
+		headers.Append("x-ms-source-if-unmodified-since", *c.input.SourceIfUnmodifiedSince)
+	}
+
+	if c.input.EncryptionScope != nil {
+		headers.Append("x-ms-encryption-scope", *c.input.EncryptionScope)
+	}
+
+	headers.Merge(metadata.SetMetaDataHeaders(c.input.MetaData))
+
+	return headers
+}
+
+func (c copyOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (c copyOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/blob/blobs/copy_abort.go
+++ b/storage/2026-02-06/blob/blobs/copy_abort.go
@@ -1,0 +1,101 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type AbortCopyInput struct {
+	// The Copy ID which should be aborted
+	CopyID string
+
+	// The ID of the Lease
+	// This must be specified if a Lease is present on the Blob, else a 403 is returned
+	LeaseID *string
+}
+
+type CopyAbortResponse struct {
+	HttpResponse *http.Response
+}
+
+// AbortCopy aborts a pending Copy Blob operation, and leaves a destination blob with zero length and full metadata.
+func (c Client) AbortCopy(ctx context.Context, containerName, blobName string, input AbortCopyInput) (result CopyAbortResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	if input.CopyID == "" {
+		err = fmt.Errorf("`input.CopyID` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: copyAbortOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type copyAbortOptions struct {
+	input AbortCopyInput
+}
+
+func (c copyAbortOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("x-ms-copy-action", "abort")
+	if c.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *c.input.LeaseID)
+	}
+
+	return headers
+}
+
+func (c copyAbortOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (c copyAbortOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "copy")
+	out.Append("copyid", c.input.CopyID)
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/copy_and_wait.go
+++ b/storage/2026-02-06/blob/blobs/copy_and_wait.go
@@ -1,0 +1,28 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+)
+
+// CopyAndWait copies a blob to a destination within the storage account and waits for it to finish copying.
+func (c Client) CopyAndWait(ctx context.Context, containerName, blobName string, input CopyInput) error {
+	if _, err := c.Copy(ctx, containerName, blobName, input); err != nil {
+		return fmt.Errorf("error copying: %s", err)
+	}
+
+	getInput := GetPropertiesInput{
+		LeaseID: input.LeaseID,
+	}
+
+	pollerType := NewCopyAndWaitPoller(&c, containerName, blobName, getInput)
+	poller := pollers.NewPoller(pollerType, 10*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+	if err := poller.PollUntilDone(ctx); err != nil {
+		return fmt.Errorf("waiting for file to copy: %+v", err)
+	}
+
+	return nil
+}

--- a/storage/2026-02-06/blob/blobs/copy_and_wait_poller.go
+++ b/storage/2026-02-06/blob/blobs/copy_and_wait_poller.go
@@ -1,0 +1,48 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+)
+
+var _ pollers.PollerType = &copyAndWaitPoller{}
+
+func NewCopyAndWaitPoller(client *Client, containerName, blobName string, getPropertiesInput GetPropertiesInput) *copyAndWaitPoller {
+	return &copyAndWaitPoller{
+		client:             client,
+		containerName:      containerName,
+		blobName:           blobName,
+		getPropertiesInput: getPropertiesInput,
+	}
+}
+
+type copyAndWaitPoller struct {
+	client             *Client
+	containerName      string
+	blobName           string
+	getPropertiesInput GetPropertiesInput
+}
+
+func (p *copyAndWaitPoller) Poll(ctx context.Context) (*pollers.PollResult, error) {
+	props, err := p.client.GetProperties(ctx, p.containerName, p.blobName, p.getPropertiesInput)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving properties (container: %s blob: %s) : %+v", p.containerName, p.blobName, err)
+	}
+
+	if strings.EqualFold(string(props.CopyStatus), string(Success)) {
+		return &pollers.PollResult{
+			Status:       pollers.PollingStatusSucceeded,
+			PollInterval: 10 * time.Second,
+		}, nil
+	}
+
+	// Processing
+	return &pollers.PollResult{
+		Status:       pollers.PollingStatusInProgress,
+		PollInterval: 10 * time.Second,
+	}, nil
+}

--- a/storage/2026-02-06/blob/blobs/copy_test.go
+++ b/storage/2026-02-06/blob/blobs/copy_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
-	"github.com/jackofallops/giovanni/storage/2020-08-04/blob/containers"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/containers"
 	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
 )
 

--- a/storage/2026-02-06/blob/blobs/copy_test.go
+++ b/storage/2026-02-06/blob/blobs/copy_test.go
@@ -1,0 +1,182 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2020-08-04/blob/containers"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+func TestCopyFromExistingFile(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	containerName := fmt.Sprintf("cont-%d", testhelpers.RandomInt())
+	fileName := "ubuntu.iso"
+	copiedFileName := "copied.iso"
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindBlobStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+
+	containersClient, err := containers.NewWithBaseUri(fmt.Sprintf("https://%s.blob.%s", testData.StorageAccountName, *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err = client.PrepareWithSharedKeyAuth(containersClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	_, err = containersClient.Create(ctx, containerName, containers.CreateInput{})
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error creating: %s", err))
+	}
+	defer containersClient.Delete(ctx, containerName)
+
+	baseUri := fmt.Sprintf("https://%s.blob.%s", testData.StorageAccountName, *domainSuffix)
+	blobClient, err := NewWithBaseUri(baseUri)
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err = client.PrepareWithSharedKeyAuth(blobClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	t.Logf("[DEBUG] Copying file to Blob Storage..")
+	copyInput := CopyInput{
+		CopySource: "http://releases.ubuntu.com/14.04/ubuntu-14.04.6-desktop-amd64.iso",
+	}
+
+	if err := blobClient.CopyAndWait(ctx, containerName, fileName, copyInput); err != nil {
+		t.Fatalf("Error copying: %s", err)
+	}
+
+	t.Logf("[DEBUG] Duplicating that file..")
+	copiedInput := CopyInput{
+		CopySource: fmt.Sprintf("%s/%s/%s", baseUri, containerName, fileName),
+	}
+	if err := blobClient.CopyAndWait(ctx, containerName, copiedFileName, copiedInput); err != nil {
+		t.Fatalf("Error duplicating file: %s", err)
+	}
+
+	t.Logf("[DEBUG] Retrieving Properties for the Original File..")
+	props, err := blobClient.GetProperties(ctx, containerName, fileName, GetPropertiesInput{})
+	if err != nil {
+		t.Fatalf("Error getting properties for the original file: %s", err)
+	}
+
+	t.Logf("[DEBUG] Retrieving Properties for the Copied File..")
+	copiedProps, err := blobClient.GetProperties(ctx, containerName, copiedFileName, GetPropertiesInput{})
+	if err != nil {
+		t.Fatalf("Error getting properties for the copied file: %s", err)
+	}
+
+	if props.ContentLength != copiedProps.ContentLength {
+		t.Fatalf("Expected the content length to be %d but it was %d", props.ContentLength, copiedProps.ContentLength)
+	}
+
+	t.Logf("[DEBUG] Deleting copied file..")
+	if _, err := blobClient.Delete(ctx, containerName, copiedFileName, DeleteInput{}); err != nil {
+		t.Fatalf("Error deleting file: %s", err)
+	}
+
+	t.Logf("[DEBUG] Deleting original file..")
+	if _, err := blobClient.Delete(ctx, containerName, fileName, DeleteInput{}); err != nil {
+		t.Fatalf("Error deleting file: %s", err)
+	}
+}
+
+func TestCopyFromURL(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	containerName := fmt.Sprintf("cont-%d", testhelpers.RandomInt())
+	fileName := "ubuntu.iso"
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindBlobStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+
+	containersClient, err := containers.NewWithBaseUri(fmt.Sprintf("https://%s.blob.%s", testData.StorageAccountName, *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err = client.PrepareWithSharedKeyAuth(containersClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	_, err = containersClient.Create(ctx, containerName, containers.CreateInput{})
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error creating: %s", err))
+	}
+	defer containersClient.Delete(ctx, containerName)
+
+	blobClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.blob.%s", testData.StorageAccountName, *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err = client.PrepareWithSharedKeyAuth(blobClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	t.Logf("[DEBUG] Copying file to Blob Storage..")
+	copyInput := CopyInput{
+		CopySource: "http://releases.ubuntu.com/14.04/ubuntu-14.04.6-desktop-amd64.iso",
+	}
+
+	if err := blobClient.CopyAndWait(ctx, containerName, fileName, copyInput); err != nil {
+		t.Fatalf("Error copying: %s", err)
+	}
+
+	t.Logf("[DEBUG] Retrieving Properties..")
+	props, err := blobClient.GetProperties(ctx, containerName, fileName, GetPropertiesInput{})
+	if err != nil {
+		t.Fatalf("Error getting properties: %s", err)
+	}
+
+	if props.ContentLength == 0 {
+		t.Fatalf("Expected the file to be there but looks like it isn't: %d", props.ContentLength)
+	}
+
+	t.Logf("[DEBUG] Deleting file..")
+	if _, err := blobClient.Delete(ctx, containerName, fileName, DeleteInput{}); err != nil {
+		t.Fatalf("Error deleting file: %s", err)
+	}
+}

--- a/storage/2026-02-06/blob/blobs/delete.go
+++ b/storage/2026-02-06/blob/blobs/delete.go
@@ -1,0 +1,95 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type DeleteInput struct {
+	// Should any Snapshots for this Blob also be deleted?
+	// If the Blob has Snapshots and this is set to False a 409 Conflict will be returned
+	DeleteSnapshots bool
+
+	// The ID of the Lease
+	// This must be specified if a Lease is present on the Blob, else a 403 is returned
+	LeaseID *string
+}
+
+type DeleteResponse struct {
+	HttpResponse *http.Response
+}
+
+// Delete marks the specified blob or snapshot for deletion. The blob is later deleted during garbage collection.
+func (c Client) Delete(ctx context.Context, containerName, blobName string, input DeleteInput) (result DeleteResponse, err error) {
+	if containerName == "" {
+		return result, fmt.Errorf("`containerName` cannot be an empty string")
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		return result, fmt.Errorf("`containerName` must be a lower-cased string")
+	}
+
+	if blobName == "" {
+		return result, fmt.Errorf("`blobName` cannot be an empty string")
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+		},
+		HttpMethod: http.MethodDelete,
+		OptionsObject: deleteOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type deleteOptions struct {
+	input DeleteInput
+}
+
+func (d deleteOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	if d.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *d.input.LeaseID)
+	}
+
+	if d.input.DeleteSnapshots {
+		headers.Append("x-ms-delete-snapshots", "include")
+	}
+
+	return headers
+}
+
+func (d deleteOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (d deleteOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/blob/blobs/delete_snapshot.go
+++ b/storage/2026-02-06/blob/blobs/delete_snapshot.go
@@ -1,0 +1,99 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type DeleteSnapshotInput struct {
+	// The ID of the Lease
+	// This must be specified if a Lease is present on the Blob, else a 403 is returned
+	LeaseID *string
+
+	// The DateTime of the Snapshot which should be marked for Deletion
+	SnapshotDateTime string
+}
+
+type DeleteSnapshotResponse struct {
+	HttpResponse *http.Response
+}
+
+// DeleteSnapshot marks a single Snapshot of a Blob for Deletion based on it's DateTime, which will be deleted during the next Garbage Collection cycle.
+func (c Client) DeleteSnapshot(ctx context.Context, containerName, blobName string, input DeleteSnapshotInput) (result DeleteSnapshotResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	if input.SnapshotDateTime == "" {
+		err = fmt.Errorf("`input.SnapshotDateTime` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+		},
+		HttpMethod: http.MethodDelete,
+		OptionsObject: deleteSnapshotOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type deleteSnapshotOptions struct {
+	input DeleteSnapshotInput
+}
+
+func (d deleteSnapshotOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	if d.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *d.input.LeaseID)
+	}
+
+	return headers
+}
+
+func (d deleteSnapshotOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (d deleteSnapshotOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("snapshot", d.input.SnapshotDateTime)
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/delete_snapshots.go
+++ b/storage/2026-02-06/blob/blobs/delete_snapshots.go
@@ -1,0 +1,90 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type DeleteSnapshotsInput struct {
+	// The ID of the Lease
+	// This must be specified if a Lease is present on the Blob, else a 403 is returned
+	LeaseID *string
+}
+
+type DeleteSnapshotsResponse struct {
+	HttpResponse *http.Response
+}
+
+// DeleteSnapshots marks all Snapshots of a Blob for Deletion, which will be deleted during the next Garbage Collection Cycle.
+func (c Client) DeleteSnapshots(ctx context.Context, containerName, blobName string, input DeleteSnapshotsInput) (result DeleteSnapshotsResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+		},
+		HttpMethod: http.MethodDelete,
+		OptionsObject: deleteSnapshotsOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type deleteSnapshotsOptions struct {
+	input DeleteSnapshotsInput
+}
+
+func (d deleteSnapshotsOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("x-ms-delete-snapshots", "only")
+
+	if d.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *d.input.LeaseID)
+	}
+	return headers
+}
+
+func (d deleteSnapshotsOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (d deleteSnapshotsOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/blob/blobs/get.go
+++ b/storage/2026-02-06/blob/blobs/get.go
@@ -1,0 +1,110 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type GetInput struct {
+	LeaseID   *string
+	StartByte *int64
+	EndByte   *int64
+}
+
+type GetResponse struct {
+	HttpResponse *http.Response
+
+	Contents *[]byte
+}
+
+// Get reads or downloads a blob from the system, including its metadata and properties.
+func (c Client) Get(ctx context.Context, containerName, blobName string, input GetInput) (result GetResponse, err error) {
+	if containerName == "" {
+		return result, fmt.Errorf("`containerName` cannot be an empty string")
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		return result, fmt.Errorf("`containerName` must be a lower-cased string")
+	}
+
+	if blobName == "" {
+		return result, fmt.Errorf("`blobName` cannot be an empty string")
+	}
+
+	if input.LeaseID != nil && *input.LeaseID == "" {
+		return result, fmt.Errorf("`input.LeaseID` should either be specified or nil, not an empty string")
+	}
+
+	if (input.StartByte != nil && input.EndByte == nil) || input.StartByte == nil && input.EndByte != nil {
+		return result, fmt.Errorf("`input.StartByte` and `input.EndByte` must both be specified, or both be nil")
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+			http.StatusPartialContent,
+		},
+		HttpMethod: http.MethodGet,
+		OptionsObject: getOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Body != nil {
+				defer resp.Body.Close()
+				respBody, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return result, fmt.Errorf("could not parse response body")
+				}
+
+				result.Contents = &respBody
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type getOptions struct {
+	input GetInput
+}
+
+func (g getOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	if g.input.StartByte != nil && g.input.EndByte != nil {
+		headers.Append("x-ms-range", fmt.Sprintf("bytes=%d-%d", *g.input.StartByte, *g.input.EndByte))
+	}
+	return headers
+
+}
+
+func (g getOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (g getOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/blob/blobs/get_block_list.go
+++ b/storage/2026-02-06/blob/blobs/get_block_list.go
@@ -1,0 +1,127 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type GetBlockListInput struct {
+	BlockListType BlockListType
+	LeaseID       *string
+}
+
+type GetBlockListResponse struct {
+	HttpResponse *http.Response
+
+	// The size of the blob in bytes
+	BlobContentLength *int64
+
+	// The Content Type of the blob
+	ContentType string
+
+	// The ETag associated with this blob
+	ETag string
+
+	// A list of blocks which have been committed
+	CommittedBlocks CommittedBlocks `xml:"CommittedBlocks,omitempty"`
+
+	// A list of blocks which have not yet been committed
+	UncommittedBlocks UncommittedBlocks `xml:"UncommittedBlocks,omitempty"`
+}
+
+// GetBlockList retrieves the list of blocks that have been uploaded as part of a block blob.
+func (c Client) GetBlockList(ctx context.Context, containerName, blobName string, input GetBlockListInput) (result GetBlockListResponse, err error) {
+	if containerName == "" {
+		return result, fmt.Errorf("`containerName` cannot be an empty string")
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		return result, fmt.Errorf("`containerName` must be a lower-cased string")
+	}
+
+	if blobName == "" {
+		return result, fmt.Errorf("`blobName` cannot be an empty string")
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		OptionsObject: getBlockListOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.ContentType = resp.Header.Get("Content-Type")
+				result.ETag = resp.Header.Get("ETag")
+
+				if v := resp.Header.Get("x-ms-blob-content-length"); v != "" {
+					i, innerErr := strconv.Atoi(v)
+					if innerErr != nil {
+						err = fmt.Errorf("parsing `x-ms-blob-content-length` header value %q: %s", v, innerErr)
+						return
+					}
+
+					i64 := int64(i)
+					result.BlobContentLength = &i64
+				}
+			}
+
+			err = resp.Unmarshal(&result)
+			if err != nil {
+				err = fmt.Errorf("unmarshalling response: %+v", err)
+				return
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type getBlockListOptions struct {
+	input GetBlockListInput
+}
+
+func (g getBlockListOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	if g.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *g.input.LeaseID)
+	}
+	return headers
+}
+
+func (g getBlockListOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (g getBlockListOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("blocklisttype", string(g.input.BlockListType))
+	out.Append("comp", "blocklist")
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/get_page_ranges.go
+++ b/storage/2026-02-06/blob/blobs/get_page_ranges.go
@@ -1,0 +1,142 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type GetPageRangesInput struct {
+	LeaseID *string
+
+	StartByte *int64
+	EndByte   *int64
+}
+
+type GetPageRangesResponse struct {
+	HttpResponse *http.Response
+
+	// The size of the blob in bytes
+	ContentLength *int64
+
+	// The Content Type of the blob
+	ContentType string
+
+	// The ETag associated with this blob
+	ETag string
+
+	PageRanges []PageRange `xml:"PageRange"`
+}
+
+type PageRange struct {
+	// The start byte offset for this range, inclusive
+	Start int64 `xml:"Start"`
+
+	// The end byte offset for this range, inclusive
+	End int64 `xml:"End"`
+}
+
+// GetPageRanges returns the list of valid page ranges for a page blob or snapshot of a page blob.
+func (c Client) GetPageRanges(ctx context.Context, containerName, blobName string, input GetPageRangesInput) (result GetPageRangesResponse, err error) {
+	if containerName == "" {
+		return result, fmt.Errorf("`containerName` cannot be an empty string")
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		return result, fmt.Errorf("`containerName` must be a lower-cased string")
+	}
+
+	if blobName == "" {
+		return result, fmt.Errorf("`blobName` cannot be an empty string")
+	}
+
+	if (input.StartByte != nil && input.EndByte == nil) || (input.StartByte == nil && input.EndByte != nil) {
+		return result, fmt.Errorf("`input.StartByte` and `input.EndByte` must both be specified, or both be nil")
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		OptionsObject: getPageRangesOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.ContentType = resp.Header.Get("Content-Type")
+				result.ETag = resp.Header.Get("ETag")
+
+				if v := resp.Header.Get("x-ms-blob-content-length"); v != "" {
+					i, innerErr := strconv.Atoi(v)
+					if innerErr != nil {
+						err = fmt.Errorf("parsing `x-ms-blob-content-length` header value %q: %+v", v, innerErr)
+						return
+					}
+
+					i64 := int64(i)
+					result.ContentLength = &i64
+				}
+			}
+
+			err = resp.Unmarshal(&result)
+			if err != nil {
+				err = fmt.Errorf("unmarshalling response: %+v", err)
+				return
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type getPageRangesOptions struct {
+	input GetPageRangesInput
+}
+
+func (g getPageRangesOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	if g.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *g.input.LeaseID)
+	}
+
+	if g.input.StartByte != nil && g.input.EndByte != nil {
+		headers.Append("x-ms-range", fmt.Sprintf("bytes=%d-%d", *g.input.StartByte, *g.input.EndByte))
+	}
+
+	return headers
+}
+
+func (g getPageRangesOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (g getPageRangesOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "pagelist")
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/incremental_copy_blob.go
+++ b/storage/2026-02-06/blob/blobs/incremental_copy_blob.go
@@ -1,0 +1,112 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type IncrementalCopyBlobInput struct {
+	CopySource        string
+	IfModifiedSince   *string
+	IfUnmodifiedSince *string
+	IfMatch           *string
+	IfNoneMatch       *string
+}
+
+type IncrementalCopyBlob struct {
+	HttpResponse *http.Response
+}
+
+// IncrementalCopyBlob copies a snapshot of the source page blob to a destination page blob.
+// The snapshot is copied such that only the differential changes between the previously copied
+// snapshot are transferred to the destination.
+// The copied snapshots are complete copies of the original snapshot and can be read or copied from as usual.
+func (c Client) IncrementalCopyBlob(ctx context.Context, containerName, blobName string, input IncrementalCopyBlobInput) (result IncrementalCopyBlob, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	if input.CopySource == "" {
+		err = fmt.Errorf("`input.CopySource` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: incrementalCopyBlobOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type incrementalCopyBlobOptions struct {
+	input IncrementalCopyBlobInput
+}
+
+func (i incrementalCopyBlobOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	headers.Append("x-ms-copy-source", i.input.CopySource)
+
+	if i.input.IfModifiedSince != nil {
+		headers.Append("If-Modified-Since", *i.input.IfModifiedSince)
+	}
+	if i.input.IfUnmodifiedSince != nil {
+		headers.Append("If-Unmodified-Since", *i.input.IfUnmodifiedSince)
+	}
+	if i.input.IfMatch != nil {
+		headers.Append("If-Match", *i.input.IfMatch)
+	}
+	if i.input.IfNoneMatch != nil {
+		headers.Append("If-None-Match", *i.input.IfNoneMatch)
+	}
+	return headers
+}
+
+func (i incrementalCopyBlobOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (i incrementalCopyBlobOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "incrementalcopy")
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/lease_acquire.go
+++ b/storage/2026-02-06/blob/blobs/lease_acquire.go
@@ -1,0 +1,129 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type AcquireLeaseInput struct {
+	// The ID of the existing Lease, if leased
+	LeaseID *string
+
+	// Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires.
+	// A non-infinite lease can be between 15 and 60 seconds
+	LeaseDuration int
+
+	// The Proposed new ID for the Lease
+	ProposedLeaseID *string
+}
+
+type AcquireLeaseResponse struct {
+	HttpResponse *http.Response
+
+	LeaseID string
+}
+
+// AcquireLease establishes and manages a lock on a blob for write and delete operations.
+func (c Client) AcquireLease(ctx context.Context, containerName, blobName string, input AcquireLeaseInput) (result AcquireLeaseResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	if input.LeaseID != nil && *input.LeaseID == "" {
+		err = fmt.Errorf("`input.LeaseID` cannot be an empty string, if specified")
+		return
+	}
+
+	if input.ProposedLeaseID != nil && *input.ProposedLeaseID == "" {
+		err = fmt.Errorf("`input.ProposedLeaseID` cannot be an empty string, if specified")
+		return
+	}
+	// An infinite lease duration is -1 seconds. A non-infinite lease can be between 15 and 60 seconds
+	if input.LeaseDuration != -1 && (input.LeaseDuration <= 15 || input.LeaseDuration >= 60) {
+		err = fmt.Errorf("`input.LeaseDuration` must be -1 (infinite), or between 15 and 60 seconds")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: acquireLeaseOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Response != nil && resp.Header != nil {
+				result.LeaseID = resp.Header.Get("x-ms-lease-id")
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type acquireLeaseOptions struct {
+	input AcquireLeaseInput
+}
+
+func (a acquireLeaseOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	headers.Append("x-ms-lease-action", "acquire")
+	headers.Append("x-ms-lease-duration", strconv.Itoa(a.input.LeaseDuration))
+
+	if a.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *a.input.LeaseID)
+	}
+
+	if a.input.ProposedLeaseID != nil {
+		headers.Append("x-ms-proposed-lease-id", *a.input.ProposedLeaseID)
+	}
+
+	return headers
+}
+
+func (a acquireLeaseOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (a acquireLeaseOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "lease")
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/lease_break.go
+++ b/storage/2026-02-06/blob/blobs/lease_break.go
@@ -1,0 +1,113 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type BreakLeaseInput struct {
+	//  For a break operation, proposed duration the lease should continue
+	//  before it is broken, in seconds, between 0 and 60.
+	//  This break period is only used if it is shorter than the time remaining on the lease.
+	//  If longer, the time remaining on the lease is used.
+	//  A new lease will not be available before the break period has expired,
+	//  but the lease may be held for longer than the break period.
+	//  If this header does not appear with a break operation, a fixed-duration lease breaks
+	//  after the remaining lease period elapses, and an infinite lease breaks immediately.
+	BreakPeriod *int
+
+	LeaseID string
+}
+
+type BreakLeaseResponse struct {
+	HttpResponse *http.Response
+
+	// Approximate time remaining in the lease period, in seconds.
+	// If the break is immediate, 0 is returned.
+	LeaseTime int
+}
+
+// BreakLease breaks an existing lock on a blob using the LeaseID.
+func (c Client) BreakLease(ctx context.Context, containerName, blobName string, input BreakLeaseInput) (result BreakLeaseResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	if input.LeaseID == "" {
+		err = fmt.Errorf("`input.LeaseID` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: breakLeaseOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type breakLeaseOptions struct {
+	input BreakLeaseInput
+}
+
+func (b breakLeaseOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	headers.Append("x-ms-lease-action", "break")
+	headers.Append("x-ms-lease-id", b.input.LeaseID)
+
+	if b.input.BreakPeriod != nil {
+		headers.Append("x-ms-lease-break-period", strconv.Itoa(*b.input.BreakPeriod))
+	}
+
+	return headers
+}
+
+func (b breakLeaseOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (b breakLeaseOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "lease")
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/lease_change.go
+++ b/storage/2026-02-06/blob/blobs/lease_change.go
@@ -1,0 +1,107 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type ChangeLeaseInput struct {
+	ExistingLeaseID string
+	ProposedLeaseID string
+}
+
+type ChangeLeaseResponse struct {
+	HttpResponse *http.Response
+
+	LeaseID string
+}
+
+// ChangeLease changes an existing lock on a blob for another lock.
+func (c Client) ChangeLease(ctx context.Context, containerName, blobName string, input ChangeLeaseInput) (result ChangeLeaseResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	if input.ExistingLeaseID == "" {
+		err = fmt.Errorf("`input.ExistingLeaseID` cannot be an empty string")
+		return
+	}
+
+	if input.ProposedLeaseID == "" {
+		err = fmt.Errorf("`input.ProposedLeaseID` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: changeLeaseOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Response != nil && resp.Header != nil {
+				result.LeaseID = resp.Header.Get("x-ms-lease-id")
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type changeLeaseOptions struct {
+	input ChangeLeaseInput
+}
+
+func (c changeLeaseOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("x-ms-lease-action", "change")
+	headers.Append("x-ms-lease-id", c.input.ExistingLeaseID)
+	headers.Append("x-ms-proposed-lease-id", c.input.ProposedLeaseID)
+	return headers
+}
+
+func (c changeLeaseOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (c changeLeaseOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "lease")
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/lease_release.go
+++ b/storage/2026-02-06/blob/blobs/lease_release.go
@@ -1,0 +1,92 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type ReleaseLeaseResponse struct {
+	HttpResponse *http.Response
+}
+
+type ReleaseLeaseInput struct {
+	LeaseID string
+}
+
+// ReleaseLease releases a lock based on the Lease ID.
+func (c Client) ReleaseLease(ctx context.Context, containerName, blobName string, input ReleaseLeaseInput) (result ReleaseLeaseResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	if input.LeaseID == "" {
+		err = fmt.Errorf("`input.LeaseID` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: releaseLeaseOptions{
+			leaseID: input.LeaseID,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type releaseLeaseOptions struct {
+	leaseID string
+}
+
+func (r releaseLeaseOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("x-ms-lease-action", "release")
+	headers.Append("x-ms-lease-id", r.leaseID)
+	return headers
+}
+
+func (r releaseLeaseOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (r releaseLeaseOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "lease")
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/lease_renew.go
+++ b/storage/2026-02-06/blob/blobs/lease_renew.go
@@ -1,0 +1,91 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type RenewLeaseResponse struct {
+	HttpResponse *http.Response
+}
+
+type RenewLeaseInput struct {
+	LeaseID string
+}
+
+func (c Client) RenewLease(ctx context.Context, containerName, blobName string, input RenewLeaseInput) (result RenewLeaseResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	if input.LeaseID == "" {
+		err = fmt.Errorf("`input.LeaseID` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: renewLeaseOptions{
+			leaseID: input.LeaseID,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type renewLeaseOptions struct {
+	leaseID string
+}
+
+func (r renewLeaseOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("x-ms-lease-action", "renew")
+	headers.Append("x-ms-lease-id", r.leaseID)
+	return headers
+}
+
+func (r renewLeaseOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (r renewLeaseOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "lease")
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/lease_test.go
+++ b/storage/2026-02-06/blob/blobs/lease_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
-	"github.com/jackofallops/giovanni/storage/2020-08-04/blob/containers"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/containers"
 	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
 )
 

--- a/storage/2026-02-06/blob/blobs/lease_test.go
+++ b/storage/2026-02-06/blob/blobs/lease_test.go
@@ -1,0 +1,123 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2020-08-04/blob/containers"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+func TestLeaseLifecycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	containerName := fmt.Sprintf("cont-%d", testhelpers.RandomInt())
+	fileName := "ubuntu.iso"
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindBlobStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+
+	containersClient, err := containers.NewWithBaseUri(fmt.Sprintf("https://%s.blob.%s", testData.StorageAccountName, *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err = client.PrepareWithSharedKeyAuth(containersClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	_, err = containersClient.Create(ctx, containerName, containers.CreateInput{})
+	if err != nil {
+		t.Fatal(fmt.Errorf("error creating: %s", err))
+	}
+	defer containersClient.Delete(ctx, containerName)
+
+	blobClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.blob.%s", testData.StorageAccountName, *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err = client.PrepareWithSharedKeyAuth(blobClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	t.Logf("[DEBUG] Copying file to Blob Storage..")
+	copyInput := CopyInput{
+		CopySource: "http://releases.ubuntu.com/14.04/ubuntu-14.04.6-desktop-amd64.iso",
+	}
+
+	if err := blobClient.CopyAndWait(ctx, containerName, fileName, copyInput); err != nil {
+		t.Fatalf("Error copying: %s", err)
+	}
+	defer blobClient.Delete(ctx, containerName, fileName, DeleteInput{})
+
+	// Test begins here
+	t.Logf("[DEBUG] Acquiring Lease..")
+	leaseInput := AcquireLeaseInput{
+		LeaseDuration: -1,
+	}
+	leaseInfo, err := blobClient.AcquireLease(ctx, containerName, fileName, leaseInput)
+	if err != nil {
+		t.Fatalf("Error acquiring lease: %s", err)
+	}
+	t.Logf("[DEBUG] Lease ID: %q", leaseInfo.LeaseID)
+
+	t.Logf("[DEBUG] Changing Lease..")
+	changeLeaseInput := ChangeLeaseInput{
+		ExistingLeaseID: leaseInfo.LeaseID,
+		ProposedLeaseID: "31f5bb01-cdd9-4166-bcdc-95186076bde0",
+	}
+	changeLeaseResult, err := blobClient.ChangeLease(ctx, containerName, fileName, changeLeaseInput)
+	if err != nil {
+		t.Fatalf("Error changing lease: %s", err)
+	}
+	t.Logf("[DEBUG] New Lease ID: %q", changeLeaseResult.LeaseID)
+
+	t.Logf("[DEBUG] Releasing Lease..")
+	if _, err := blobClient.ReleaseLease(ctx, containerName, fileName, ReleaseLeaseInput{LeaseID: changeLeaseResult.LeaseID}); err != nil {
+		t.Fatalf("Error releasing lease: %s", err)
+	}
+
+	t.Logf("[DEBUG] Acquiring a new lease..")
+	leaseInput = AcquireLeaseInput{
+		LeaseDuration: 30,
+	}
+	leaseInfo, err = blobClient.AcquireLease(ctx, containerName, fileName, leaseInput)
+	if err != nil {
+		t.Fatalf("Error acquiring lease: %s", err)
+	}
+	t.Logf("[DEBUG] Lease ID: %q", leaseInfo.LeaseID)
+
+	t.Logf("[DEBUG] Renewing lease..")
+	if _, err := blobClient.RenewLease(ctx, containerName, fileName, RenewLeaseInput{LeaseID: leaseInfo.LeaseID}); err != nil {
+		t.Fatalf("Error renewing lease: %s", err)
+	}
+
+	t.Logf("[DEBUG] Breaking lease..")
+	breakLeaseInput := BreakLeaseInput{
+		LeaseID: leaseInfo.LeaseID,
+	}
+	if _, err := blobClient.BreakLease(ctx, containerName, fileName, breakLeaseInput); err != nil {
+		t.Fatalf("Error breaking lease: %s", err)
+	}
+}

--- a/storage/2026-02-06/blob/blobs/lifecycle_test.go
+++ b/storage/2026-02-06/blob/blobs/lifecycle_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
-	"github.com/jackofallops/giovanni/storage/2020-08-04/blob/containers"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/containers"
 	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
 )
 
@@ -96,10 +96,8 @@ func TestLifecycle(t *testing.T) {
 		t.Fatalf("Error listing blobs: %s", err)
 	}
 
-	if model := listResult.Model; model != nil {
-		if len(model.Blobs.Blobs) != 1 {
-			t.Fatalf("Expected there to be 1 blob in the container but got %d", len(model.Blobs.Blobs))
-		}
+	if blobs := listResult.Blobs; len(blobs.Blobs) != 1 {
+		t.Fatalf("Expected there to be 1 blob in the container but got %d", len(blobs.Blobs))
 	}
 
 	t.Logf("[DEBUG] Setting MetaData..")

--- a/storage/2026-02-06/blob/blobs/lifecycle_test.go
+++ b/storage/2026-02-06/blob/blobs/lifecycle_test.go
@@ -1,0 +1,179 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2020-08-04/blob/containers"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+var _ StorageBlob = Client{}
+
+func TestLifecycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	containerName := fmt.Sprintf("cont-%d", testhelpers.RandomInt())
+	fileName := "example.txt"
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindStorageVTwo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+
+	containersClient, err := containers.NewWithBaseUri(fmt.Sprintf("https://%s.blob.%s", testData.StorageAccountName, *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err = client.PrepareWithSharedKeyAuth(containersClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	_, err = containersClient.Create(ctx, containerName, containers.CreateInput{})
+	if err != nil {
+		t.Fatal(fmt.Errorf("error creating: %s", err))
+	}
+	defer containersClient.Delete(ctx, containerName)
+
+	blobClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.blob.%s", testData.StorageAccountName, *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err = client.PrepareWithSharedKeyAuth(blobClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	t.Logf("[DEBUG] Copying file to Blob Storage..")
+	copyInput := CopyInput{
+		CopySource: "http://releases.ubuntu.com/14.04/ubuntu-14.04.6-desktop-amd64.iso",
+	}
+
+	if err := blobClient.CopyAndWait(ctx, containerName, fileName, copyInput); err != nil {
+		t.Fatalf("Error copying: %s", err)
+	}
+
+	t.Logf("[DEBUG] Retrieving Blob Properties..")
+	details, err := blobClient.GetProperties(ctx, containerName, fileName, GetPropertiesInput{})
+	if err != nil {
+		t.Fatalf("Error retrieving properties: %s", err)
+	}
+
+	// default value
+	if details.AccessTier != Hot {
+		t.Fatalf("Expected the AccessTier to be %q but got %q", Hot, details.AccessTier)
+	}
+	if details.BlobType != BlockBlob {
+		t.Fatalf("Expected BlobType to be %q but got %q", BlockBlob, details.BlobType)
+	}
+	if len(details.MetaData) != 0 {
+		t.Fatalf("Expected there to be no items of metadata but got %d", len(details.MetaData))
+	}
+
+	t.Logf("[DEBUG] Checking it's returned in the List API..")
+	listInput := containers.ListBlobsInput{}
+	listResult, err := containersClient.ListBlobs(ctx, containerName, listInput)
+	if err != nil {
+		t.Fatalf("Error listing blobs: %s", err)
+	}
+
+	if model := listResult.Model; model != nil {
+		if len(model.Blobs.Blobs) != 1 {
+			t.Fatalf("Expected there to be 1 blob in the container but got %d", len(model.Blobs.Blobs))
+		}
+	}
+
+	t.Logf("[DEBUG] Setting MetaData..")
+	metaDataInput := SetMetaDataInput{
+		MetaData: map[string]string{
+			"hello": "there",
+		},
+	}
+	if _, err := blobClient.SetMetaData(ctx, containerName, fileName, metaDataInput); err != nil {
+		t.Fatalf("Error setting MetaData: %s", err)
+	}
+
+	t.Logf("[DEBUG] Re-retrieving Blob Properties..")
+	details, err = blobClient.GetProperties(ctx, containerName, fileName, GetPropertiesInput{})
+	if err != nil {
+		t.Fatalf("Error re-retrieving properties: %s", err)
+	}
+
+	// default value
+	if details.AccessTier != Hot {
+		t.Fatalf("Expected the AccessTier to be %q but got %q", Hot, details.AccessTier)
+	}
+	if details.BlobType != BlockBlob {
+		t.Fatalf("Expected BlobType to be %q but got %q", BlockBlob, details.BlobType)
+	}
+	if len(details.MetaData) != 1 {
+		t.Fatalf("Expected there to be 1 item of metadata but got %d", len(details.MetaData))
+	}
+	if details.MetaData["hello"] != "there" {
+		t.Fatalf("Expected `hello` to be `there` but got %q", details.MetaData["there"])
+	}
+
+	t.Logf("[DEBUG] Retrieving the Block List..")
+	getBlockListInput := GetBlockListInput{
+		BlockListType: All,
+	}
+	blockList, err := blobClient.GetBlockList(ctx, containerName, fileName, getBlockListInput)
+	if err != nil {
+		t.Fatalf("Error retrieving Block List: %s", err)
+	}
+
+	// since this is a copy from an existing file, all blocks should be present
+	if len(blockList.CommittedBlocks.Blocks) == 0 {
+		t.Fatalf("Expected there to be committed blocks but there weren't!")
+	}
+	if len(blockList.UncommittedBlocks.Blocks) != 0 {
+		t.Fatalf("Expected all blocks to be committed but got %d uncommitted blocks", len(blockList.UncommittedBlocks.Blocks))
+	}
+
+	t.Logf("[DEBUG] Changing the Access Tiers..")
+	tiers := []AccessTier{
+		Hot,
+		Cool,
+		Archive,
+	}
+	for _, tier := range tiers {
+		t.Logf("[DEBUG] Updating the Access Tier to %q..", string(tier))
+		if _, err := blobClient.SetTier(ctx, containerName, fileName, SetTierInput{Tier: tier}); err != nil {
+			t.Fatalf("Error setting the Access Tier: %s", err)
+		}
+
+		t.Logf("[DEBUG] Re-retrieving Blob Properties..")
+		details, err = blobClient.GetProperties(ctx, containerName, fileName, GetPropertiesInput{})
+		if err != nil {
+			t.Fatalf("Error re-retrieving properties: %s", err)
+		}
+
+		if details.AccessTier != tier {
+			t.Fatalf("Expected the AccessTier to be %q but got %q", tier, details.AccessTier)
+		}
+	}
+
+	t.Logf("[DEBUG] Deleting Blob")
+	if _, err := blobClient.Delete(ctx, containerName, fileName, DeleteInput{}); err != nil {
+		t.Fatalf("Error deleting Blob: %s", err)
+	}
+}

--- a/storage/2026-02-06/blob/blobs/metadata_set.go
+++ b/storage/2026-02-06/blob/blobs/metadata_set.go
@@ -1,0 +1,106 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type SetMetaDataInput struct {
+	// The ID of the Lease
+	// This must be specified if a Lease is present on the Blob, else a 403 is returned
+	LeaseID *string
+
+	// Any metadata which should be added to this blob
+	MetaData map[string]string
+
+	// The encryption scope for the blob.
+	EncryptionScope *string
+}
+
+type SetMetaDataResponse struct {
+	HttpResponse *http.Response
+}
+
+// SetMetaData marks the specified blob or snapshot for deletion. The blob is later deleted during garbage collection.
+func (c Client) SetMetaData(ctx context.Context, containerName, blobName string, input SetMetaDataInput) (result SetMetaDataResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	if err = metadata.Validate(input.MetaData); err != nil {
+		err = fmt.Errorf(fmt.Sprintf("`input.MetaData` is not valid: %s.", err))
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: setMetadataOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type setMetadataOptions struct {
+	input SetMetaDataInput
+}
+
+func (s setMetadataOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	if s.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *s.input.LeaseID)
+	}
+	if s.input.EncryptionScope != nil {
+		headers.Append("x-ms-encryption-scope", *s.input.EncryptionScope)
+	}
+	headers.Merge(metadata.SetMetaDataHeaders(s.input.MetaData))
+	return headers
+}
+
+func (s setMetadataOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (s setMetadataOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "metadata")
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/models.go
+++ b/storage/2026-02-06/blob/blobs/models.go
@@ -1,0 +1,82 @@
+package blobs
+
+type AccessTier string
+
+var (
+	Archive AccessTier = "Archive"
+	Cool    AccessTier = "Cool"
+	Hot     AccessTier = "Hot"
+)
+
+type ArchiveStatus string
+
+var (
+	None                   ArchiveStatus = ""
+	RehydratePendingToCool ArchiveStatus = "rehydrate-pending-to-cool"
+	RehydratePendingToHot  ArchiveStatus = "rehydrate-pending-to-hot"
+)
+
+type BlockListType string
+
+var (
+	All         BlockListType = "all"
+	Committed   BlockListType = "committed"
+	Uncommitted BlockListType = "uncommitted"
+)
+
+type Block struct {
+	// The base64-encoded Block ID
+	Name string `xml:"Name"`
+
+	// The size of the Block in Bytes
+	Size int64 `xml:"Size"`
+}
+
+type BlobType string
+
+var (
+	AppendBlob BlobType = "AppendBlob"
+	BlockBlob  BlobType = "BlockBlob"
+	PageBlob   BlobType = "PageBlob"
+)
+
+type CommittedBlocks struct {
+	Blocks []Block `xml:"Block"`
+}
+
+type CopyStatus string
+
+var (
+	Aborted CopyStatus = "aborted"
+	Failed  CopyStatus = "failed"
+	Pending CopyStatus = "pending"
+	Success CopyStatus = "success"
+)
+
+type LeaseDuration string
+
+var (
+	Fixed    LeaseDuration = "fixed"
+	Infinite LeaseDuration = "infinite"
+)
+
+type LeaseState string
+
+var (
+	Available LeaseState = "available"
+	Breaking  LeaseState = "breaking"
+	Broken    LeaseState = "broken"
+	Expired   LeaseState = "expired"
+	Leased    LeaseState = "leased"
+)
+
+type LeaseStatus string
+
+var (
+	Locked   LeaseStatus = "locked"
+	Unlocked LeaseStatus = "unlocked"
+)
+
+type UncommittedBlocks struct {
+	Blocks []Block `xml:"Block"`
+}

--- a/storage/2026-02-06/blob/blobs/properties_get.go
+++ b/storage/2026-02-06/blob/blobs/properties_get.go
@@ -1,0 +1,297 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type GetPropertiesInput struct {
+	// The ID of the Lease
+	// This must be specified if a Lease is present on the Blob, else a 403 is returned
+	LeaseID *string
+}
+
+type GetPropertiesResponse struct {
+	HttpResponse *http.Response
+
+	// The tier of page blob on a premium storage account or tier of block blob on blob storage or general purpose v2 account.
+	AccessTier AccessTier
+
+	// This gives the last time tier was changed on the object.
+	// This header is returned only if tier on block blob was ever set.
+	// The date format follows RFC 1123
+	AccessTierChangeTime string
+
+	// For page blobs on a premium storage account only.
+	// If the access tier is not explicitly set on the blob, the tier is inferred based on its content length
+	// and this header will be returned with true value.
+	// For block blobs on Blob Storage or general purpose v2 account, if the blob does not have the access tier
+	// set then we infer the tier from the storage account properties. This header is set only if the block blob
+	// tier is inferred
+	AccessTierInferred bool
+
+	// For blob storage or general purpose v2 account.
+	// If the blob is being rehydrated and is not complete then this header is returned indicating
+	// that rehydrate is pending and also tells the destination tier
+	ArchiveStatus ArchiveStatus
+
+	// The number of committed blocks present in the blob.
+	// This header is returned only for append blobs.
+	BlobCommittedBlockCount string
+
+	// The current sequence number for a page blob.
+	// This header is not returned for block blobs or append blobs.
+	// This header is not returned for block blobs.
+	BlobSequenceNumber string
+
+	// The blob type.
+	BlobType BlobType
+
+	// If the Cache-Control request header has previously been set for the blob, that value is returned in this header.
+	CacheControl string
+
+	// The Content-Disposition response header field conveys additional information about how to process
+	// the response payload, and also can be used to attach additional metadata.
+	// For example, if set to attachment, it indicates that the user-agent should not display the response,
+	// but instead show a Save As dialog.
+	ContentDisposition string
+
+	// If the Content-Encoding request header has previously been set for the blob,
+	// that value is returned in this header.
+	ContentEncoding string
+
+	// If the Content-Language request header has previously been set for the blob,
+	// that value is returned in this header.
+	ContentLanguage string
+
+	// The size of the blob in bytes.
+	// For a page blob, this header returns the value of the x-ms-blob-content-length header stored with the blob.
+	ContentLength int64
+
+	// The content type specified for the blob.
+	// If no content type was specified, the default content type is `application/octet-stream`.
+	ContentType string
+
+	// If the Content-MD5 header has been set for the blob, this response header is returned so that
+	// the client can check for message content integrity.
+	ContentMD5 string
+
+	// Conclusion time of the last attempted Copy Blob operation where this blob was the destination blob.
+	// This value can specify the time of a completed, aborted, or failed copy attempt.
+	// This header does not appear if a copy is pending, if this blob has never been the
+	// destination in a Copy Blob operation, or if this blob has been modified after a concluded Copy Blob
+	// operation using Set Blob Properties, Put Blob, or Put Block List.
+	CopyCompletionTime string
+
+	// Included if the blob is incremental copy blob or incremental copy snapshot, if x-ms-copy-status is success.
+	// Snapshot time of the last successful incremental copy snapshot for this blob
+	CopyDestinationSnapshot string
+
+	// String identifier for the last attempted Copy Blob operation where this blob was the destination blob.
+	// This header does not appear if this blob has never been the destination in a Copy Blob operation,
+	// or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties,
+	// Put Blob, or Put Block List.
+	CopyID string
+
+	// Contains the number of bytes copied and the total bytes in the source in the last attempted
+	// Copy Blob operation where this blob was the destination blob.
+	// Can show between 0 and Content-Length bytes copied.
+	// This header does not appear if this blob has never been the destination in a Copy Blob operation,
+	// or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties,
+	// Put Blob, or Put Block List.
+	CopyProgress string
+
+	// URL up to 2 KB in length that specifies the source blob used in the last attempted Copy Blob operation
+	// where this blob was the destination blob.
+	// This header does not appear if this blob has never been the destination in a Copy Blob operation,
+	// or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties,
+	// Put Blob, or Put Block List
+	CopySource string
+
+	// State of the copy operation identified by x-ms-copy-id, with these values:
+	// - success: Copy completed successfully.
+	// - pending: Copy is in progress.
+	//            Check x-ms-copy-status-description if intermittent, non-fatal errors
+	//            impede copy progress but don’t cause failure.
+	// - aborted: Copy was ended by Abort Copy Blob.
+	// - failed: Copy failed. See x-ms- copy-status-description for failure details.
+	// This header does not appear if this blob has never been the destination in a Copy Blob operation,
+	// or if this blob has been modified after a completed Copy Blob operation using Set Blob Properties,
+	// Put Blob, or Put Block List.
+	CopyStatus CopyStatus
+
+	// Describes cause of fatal or non-fatal copy operation failure.
+	// This header does not appear if this blob has never been the destination in a Copy Blob operation,
+	// or if this blob has been modified after a concluded Copy Blob operation using Set Blob Properties,
+	// Put Blob, or Put Block List.
+	CopyStatusDescription string
+
+	// The date/time at which the blob was created. The date format follows RFC 1123
+	CreationTime string
+
+	// The ETag contains a value that you can use to perform operations conditionally
+	ETag string
+
+	// Included if the blob is incremental copy blob.
+	IncrementalCopy bool
+
+	// The date/time that the blob was last modified. The date format follows RFC 1123.
+	LastModified string
+
+	// When a blob is leased, specifies whether the lease is of infinite or fixed duration
+	LeaseDuration LeaseDuration
+
+	// The lease state of the blob
+	LeaseState LeaseState
+
+	LeaseStatus LeaseStatus
+
+	// A set of name-value pairs that correspond to the user-defined metadata associated with this blob
+	MetaData map[string]string
+
+	// Is the Storage Account encrypted using server-side encryption? This should always return true
+	ServerEncrypted bool
+
+	// The encryption scope for the request content.
+	EncryptionScope string
+}
+
+// GetProperties returns all user-defined metadata, standard HTTP properties, and system properties for the blob
+func (c Client) GetProperties(ctx context.Context, containerName, blobName string, input GetPropertiesInput) (result GetPropertiesResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodHead,
+		OptionsObject: getPropertiesOptions{
+			leaseID: input.LeaseID,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.AccessTier = AccessTier(resp.Header.Get("x-ms-access-tier"))
+				result.AccessTierChangeTime = resp.Header.Get("x-ms-access-tier-change-time")
+				result.ArchiveStatus = ArchiveStatus(resp.Header.Get("x-ms-archive-status"))
+				result.BlobCommittedBlockCount = resp.Header.Get("x-ms-blob-committed-block-count")
+				result.BlobSequenceNumber = resp.Header.Get("x-ms-blob-sequence-number")
+				result.BlobType = BlobType(resp.Header.Get("x-ms-blob-type"))
+				result.CacheControl = resp.Header.Get("Cache-Control")
+				result.ContentDisposition = resp.Header.Get("Content-Disposition")
+				result.ContentEncoding = resp.Header.Get("Content-Encoding")
+				result.ContentLanguage = resp.Header.Get("Content-Language")
+				result.ContentMD5 = resp.Header.Get("Content-MD5")
+				result.ContentType = resp.Header.Get("Content-Type")
+				result.CopyCompletionTime = resp.Header.Get("x-ms-copy-completion-time")
+				result.CopyDestinationSnapshot = resp.Header.Get("x-ms-copy-destination-snapshot")
+				result.CopyID = resp.Header.Get("x-ms-copy-id")
+				result.CopyProgress = resp.Header.Get("x-ms-copy-progress")
+				result.CopySource = resp.Header.Get("x-ms-copy-source")
+				result.CopyStatus = CopyStatus(resp.Header.Get("x-ms-copy-status"))
+				result.CopyStatusDescription = resp.Header.Get("x-ms-copy-status-description")
+				result.CreationTime = resp.Header.Get("x-ms-creation-time")
+				result.ETag = resp.Header.Get("Etag")
+				result.LastModified = resp.Header.Get("Last-Modified")
+				result.LeaseDuration = LeaseDuration(resp.Header.Get("x-ms-lease-duration"))
+				result.LeaseState = LeaseState(resp.Header.Get("x-ms-lease-state"))
+				result.LeaseStatus = LeaseStatus(resp.Header.Get("x-ms-lease-status"))
+				result.EncryptionScope = resp.Header.Get("x-ms-encryption-scope")
+				result.MetaData = metadata.ParseFromHeaders(resp.Header)
+
+				if v := resp.Header.Get("x-ms-access-tier-inferred"); v != "" {
+					b, innerErr := strconv.ParseBool(v)
+					if innerErr != nil {
+						err = fmt.Errorf("parsing `x-ms-access-tier-inferred` header value %q: %s", v, innerErr)
+						return
+					}
+					result.AccessTierInferred = b
+				}
+
+				if v := resp.Header.Get("Content-Length"); v != "" {
+					i, innerErr := strconv.Atoi(v)
+					if innerErr != nil {
+						err = fmt.Errorf("parsing `Content-Length` header value %q: %s", v, innerErr)
+					}
+					result.ContentLength = int64(i)
+				}
+
+				if v := resp.Header.Get("x-ms-incremental-copy"); v != "" {
+					b, innerErr := strconv.ParseBool(v)
+					if innerErr != nil {
+						err = fmt.Errorf("parsing `x-ms-incremental-copy` header value %q: %s", v, innerErr)
+						return
+					}
+					result.IncrementalCopy = b
+				}
+
+				if v := resp.Header.Get("x-ms-server-encrypted"); v != "" {
+					b, innerErr := strconv.ParseBool(v)
+					if innerErr != nil {
+						err = fmt.Errorf("parsing `x-ms-server-encrypted` header value %q: %s", v, innerErr)
+						return
+					}
+					result.ServerEncrypted = b
+				}
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type getPropertiesOptions struct {
+	leaseID *string
+}
+
+func (g getPropertiesOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	if g.leaseID != nil {
+		headers.Append("x-ms-lease-id", *g.leaseID)
+	}
+	return headers
+}
+
+func (g getPropertiesOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (g getPropertiesOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/blob/blobs/properties_set.go
+++ b/storage/2026-02-06/blob/blobs/properties_set.go
@@ -1,0 +1,135 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type SetPropertiesInput struct {
+	CacheControl         *string
+	ContentType          *string
+	ContentMD5           *string
+	ContentEncoding      *string
+	ContentLanguage      *string
+	LeaseID              *string
+	ContentDisposition   *string
+	ContentLength        *int64
+	SequenceNumberAction *SequenceNumberAction
+	BlobSequenceNumber   *string
+}
+
+type SetPropertiesResponse struct {
+	HttpResponse *http.Response
+
+	BlobSequenceNumber string
+	Etag               string
+}
+
+// SetProperties sets system properties on the blob.
+func (c Client) SetProperties(ctx context.Context, containerName, blobName string, input SetPropertiesInput) (result SetPropertiesResponse, err error) {
+	if containerName == "" {
+		return result, fmt.Errorf("`containerName` cannot be an empty string")
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		return result, fmt.Errorf("`containerName` must be a lower-cased string")
+	}
+
+	if blobName == "" {
+		return result, fmt.Errorf("`blobName` cannot be an empty string")
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: setPropertiesOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type SequenceNumberAction string
+
+var (
+	Increment SequenceNumberAction = "increment"
+	Max       SequenceNumberAction = "max"
+	Update    SequenceNumberAction = "update"
+)
+
+type setPropertiesOptions struct {
+	input SetPropertiesInput
+}
+
+func (s setPropertiesOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	if s.input.CacheControl != nil {
+		headers.Append("x-ms-blob-cache-control", *s.input.CacheControl)
+	}
+	if s.input.ContentDisposition != nil {
+		headers.Append("x-ms-blob-content-disposition", *s.input.ContentDisposition)
+	}
+	if s.input.ContentEncoding != nil {
+		headers.Append("x-ms-blob-content-encoding", *s.input.ContentEncoding)
+	}
+	if s.input.ContentLanguage != nil {
+		headers.Append("x-ms-blob-content-language", *s.input.ContentLanguage)
+	}
+	if s.input.ContentMD5 != nil {
+		headers.Append("x-ms-blob-content-md5", *s.input.ContentMD5)
+	}
+	if s.input.ContentType != nil {
+		headers.Append("x-ms-blob-content-type", *s.input.ContentType)
+	}
+	if s.input.ContentLength != nil {
+		headers.Append("x-ms-blob-content-length", strconv.Itoa(int(*s.input.ContentLength)))
+	}
+	if s.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *s.input.LeaseID)
+	}
+	if s.input.SequenceNumberAction != nil {
+		headers.Append("x-ms-sequence-number-action", string(*s.input.SequenceNumberAction))
+	}
+	if s.input.BlobSequenceNumber != nil {
+		headers.Append("x-ms-blob-sequence-number", *s.input.BlobSequenceNumber)
+	}
+
+	return headers
+}
+
+func (s setPropertiesOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (s setPropertiesOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "properties")
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/put_append_blob.go
+++ b/storage/2026-02-06/blob/blobs/put_append_blob.go
@@ -1,0 +1,128 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type PutAppendBlobInput struct {
+	CacheControl       *string
+	ContentDisposition *string
+	ContentEncoding    *string
+	ContentLanguage    *string
+	ContentMD5         *string
+	ContentType        *string
+	LeaseID            *string
+	EncryptionScope    *string
+	MetaData           map[string]string
+}
+
+type PutAppendBlobResponse struct {
+	HttpResponse *http.Response
+}
+
+// PutAppendBlob is a wrapper around the Put API call (with a stricter input object)
+// which creates a new append blob, or updates the content of an existing blob.
+func (c Client) PutAppendBlob(ctx context.Context, containerName, blobName string, input PutAppendBlobInput) (result PutAppendBlobResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	if err = metadata.Validate(input.MetaData); err != nil {
+		err = fmt.Errorf(fmt.Sprintf("`input.MetaData` is not valid: %s.", err))
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: putAppendBlobOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type putAppendBlobOptions struct {
+	input PutAppendBlobInput
+}
+
+func (p putAppendBlobOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	headers.Append("x-ms-blob-type", string(AppendBlob))
+	headers.Append("Content-Length", "0")
+
+	if p.input.CacheControl != nil {
+		headers.Append("x-ms-blob-cache-control", *p.input.CacheControl)
+	}
+	if p.input.ContentDisposition != nil {
+		headers.Append("x-ms-blob-content-disposition", *p.input.ContentDisposition)
+	}
+	if p.input.ContentEncoding != nil {
+		headers.Append("x-ms-blob-content-encoding", *p.input.ContentEncoding)
+	}
+	if p.input.ContentLanguage != nil {
+		headers.Append("x-ms-blob-content-language", *p.input.ContentLanguage)
+	}
+	if p.input.ContentMD5 != nil {
+		headers.Append("x-ms-blob-content-md5", *p.input.ContentMD5)
+	}
+	if p.input.ContentType != nil {
+		headers.Append("x-ms-blob-content-type", *p.input.ContentType)
+	}
+	if p.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *p.input.LeaseID)
+	}
+	if p.input.EncryptionScope != nil {
+		headers.Append("x-ms-encryption-scope", *p.input.EncryptionScope)
+	}
+
+	headers.Merge(metadata.SetMetaDataHeaders(p.input.MetaData))
+	return headers
+}
+
+func (p putAppendBlobOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (p putAppendBlobOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/blob/blobs/put_block.go
+++ b/storage/2026-02-06/blob/blobs/put_block.go
@@ -1,0 +1,119 @@
+package blobs
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type PutBlockInput struct {
+	BlockID         string
+	Content         []byte
+	ContentMD5      *string
+	LeaseID         *string
+	EncryptionScope *string
+}
+
+type PutBlockResponse struct {
+	HttpResponse *http.Response
+	ContentMD5   string
+}
+
+// PutBlock creates a new block to be committed as part of a blob.
+func (c Client) PutBlock(ctx context.Context, containerName, blobName string, input PutBlockInput) (result PutBlockResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	if input.BlockID == "" {
+		err = fmt.Errorf("`input.BlockID` cannot be an empty string")
+		return
+	}
+
+	if len(input.Content) == 0 {
+		err = fmt.Errorf("`input.Content` cannot be empty")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: putBlockOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	req.ContentLength = int64(len(input.Content))
+	req.Body = io.NopCloser(bytes.NewReader(input.Content))
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type putBlockOptions struct {
+	input PutBlockInput
+}
+
+func (p putBlockOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("Content-Length", strconv.Itoa(len(p.input.Content)))
+
+	if p.input.ContentMD5 != nil {
+		headers.Append("x-ms-blob-content-md5", *p.input.ContentMD5)
+	}
+	if p.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *p.input.LeaseID)
+	}
+	if p.input.EncryptionScope != nil {
+		headers.Append("x-ms-encryption-scope", *p.input.EncryptionScope)
+	}
+
+	return headers
+}
+
+func (p putBlockOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (p putBlockOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "block")
+	out.Append("blockid", p.input.BlockID)
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/put_block_blob.go
+++ b/storage/2026-02-06/blob/blobs/put_block_blob.go
@@ -1,0 +1,148 @@
+package blobs
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type PutBlockBlobInput struct {
+	CacheControl       *string
+	Content            *[]byte
+	ContentDisposition *string
+	ContentEncoding    *string
+	ContentLanguage    *string
+	ContentMD5         *string
+	ContentType        *string
+	LeaseID            *string
+	EncryptionScope    *string
+	MetaData           map[string]string
+}
+
+type PutBlockBlobResponse struct {
+	HttpResponse *http.Response
+}
+
+// PutBlockBlob is a wrapper around the Put API call (with a stricter input object)
+// which creates a new block append blob, or updates the content of an existing block blob.
+func (c Client) PutBlockBlob(ctx context.Context, containerName, blobName string, input PutBlockBlobInput) (result PutBlockBlobResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	if input.Content != nil && len(*input.Content) == 0 {
+		err = fmt.Errorf("`input.Content` must either be nil or not empty")
+		return
+	}
+
+	if err = metadata.Validate(input.MetaData); err != nil {
+		err = fmt.Errorf(fmt.Sprintf("`input.MetaData` is not valid: %s.", err))
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: putBlockBlobOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	if input.ContentType != nil {
+		opts.ContentType = *input.ContentType
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	if input.Content != nil {
+		req.ContentLength = int64(len(*input.Content))
+		req.Body = io.NopCloser(bytes.NewReader(*input.Content))
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type putBlockBlobOptions struct {
+	input PutBlockBlobInput
+}
+
+func (p putBlockBlobOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("x-ms-blob-type", string(BlockBlob))
+
+	if p.input.CacheControl != nil {
+		headers.Append("x-ms-blob-cache-control", *p.input.CacheControl)
+	}
+	if p.input.ContentDisposition != nil {
+		headers.Append("x-ms-blob-content-disposition", *p.input.ContentDisposition)
+	}
+	if p.input.ContentEncoding != nil {
+		headers.Append("x-ms-blob-content-encoding", *p.input.ContentEncoding)
+	}
+	if p.input.ContentLanguage != nil {
+		headers.Append("x-ms-blob-content-language", *p.input.ContentLanguage)
+	}
+	if p.input.ContentMD5 != nil {
+		headers.Append("x-ms-blob-content-md5", *p.input.ContentMD5)
+	}
+	if p.input.ContentType != nil {
+		headers.Append("x-ms-blob-content-type", *p.input.ContentType)
+	}
+	if p.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *p.input.LeaseID)
+	}
+	if p.input.EncryptionScope != nil {
+		headers.Append("x-ms-encryption-scope", *p.input.EncryptionScope)
+	}
+	if p.input.Content != nil {
+		headers.Append("Content-Length", strconv.Itoa(len(*p.input.Content)))
+	}
+
+	headers.Merge(metadata.SetMetaDataHeaders(p.input.MetaData))
+
+	return headers
+}
+
+func (p putBlockBlobOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (p putBlockBlobOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/blob/blobs/put_block_blob_file.go
+++ b/storage/2026-02-06/blob/blobs/put_block_blob_file.go
@@ -1,0 +1,34 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+)
+
+// PutBlockBlobFromFile is a helper method which takes a file, and automatically chunks it up, rather than having to do this yourself
+func (c Client) PutBlockBlobFromFile(ctx context.Context, containerName, blobName string, file *os.File, input PutBlockBlobInput) error {
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("loading file info: %s", err)
+	}
+
+	fileSize := fileInfo.Size()
+	bytes := make([]byte, fileSize)
+
+	_, err = file.ReadAt(bytes, 0)
+	if err != nil {
+		if err != io.EOF {
+			return fmt.Errorf("reading bytes: %s", err)
+		}
+	}
+
+	input.Content = &bytes
+
+	if _, err = c.PutBlockBlob(ctx, containerName, blobName, input); err != nil {
+		return fmt.Errorf("putting bytes: %s", err)
+	}
+
+	return nil
+}

--- a/storage/2026-02-06/blob/blobs/put_block_list.go
+++ b/storage/2026-02-06/blob/blobs/put_block_list.go
@@ -1,0 +1,153 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type BlockList struct {
+	CommittedBlockIDs   []BlockID `xml:"Committed,omitempty"`
+	UncommittedBlockIDs []BlockID `xml:"Uncommitted,omitempty"`
+	LatestBlockIDs      []BlockID `xml:"Latest,omitempty"`
+}
+
+type BlockID struct {
+	Value string `xml:",chardata"`
+}
+
+type PutBlockListInput struct {
+	BlockList          BlockList
+	CacheControl       *string
+	ContentDisposition *string
+	ContentEncoding    *string
+	ContentLanguage    *string
+	ContentMD5         *string
+	ContentType        *string
+	LeaseID            *string
+	EncryptionScope    *string
+	MetaData           map[string]string
+}
+
+type PutBlockListResponse struct {
+	HttpResponse *http.Response
+
+	ContentMD5   string
+	ETag         string
+	LastModified string
+}
+
+// PutBlockList writes a blob by specifying the list of block IDs that make up the blob.
+// In order to be written as part of a blob, a block must have been successfully written
+// to the server in a prior Put Block operation.
+func (c Client) PutBlockList(ctx context.Context, containerName, blobName string, input PutBlockListInput) (result PutBlockListResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: putBlockListOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	err = req.Marshal(&input.BlockList)
+	if err != nil {
+		err = fmt.Errorf("marshalling request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.ContentMD5 = resp.Header.Get("Content-MD5")
+				result.ETag = resp.Header.Get("ETag")
+				result.LastModified = resp.Header.Get("Last-Modified")
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type putBlockListOptions struct {
+	input PutBlockListInput
+}
+
+func (p putBlockListOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	if p.input.CacheControl != nil {
+		headers.Append("x-ms-blob-cache-control", *p.input.CacheControl)
+	}
+	if p.input.ContentDisposition != nil {
+		headers.Append("x-ms-blob-content-disposition", *p.input.ContentDisposition)
+	}
+	if p.input.ContentEncoding != nil {
+		headers.Append("x-ms-blob-content-encoding", *p.input.ContentEncoding)
+	}
+	if p.input.ContentLanguage != nil {
+		headers.Append("x-ms-blob-content-language", *p.input.ContentLanguage)
+	}
+	if p.input.ContentMD5 != nil {
+		headers.Append("x-ms-blob-content-md5", *p.input.ContentMD5)
+	}
+	if p.input.ContentType != nil {
+		headers.Append("x-ms-blob-content-type", *p.input.ContentType)
+	}
+	if p.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *p.input.LeaseID)
+	}
+	if p.input.EncryptionScope != nil {
+		headers.Append("x-ms-encryption-scope", *p.input.EncryptionScope)
+	}
+
+	headers.Merge(metadata.SetMetaDataHeaders(p.input.MetaData))
+
+	return headers
+}
+
+func (p putBlockListOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (p putBlockListOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "blocklist")
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/put_block_url.go
+++ b/storage/2026-02-06/blob/blobs/put_block_url.go
@@ -1,0 +1,124 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type PutBlockFromURLInput struct {
+	BlockID    string
+	CopySource string
+
+	ContentMD5      *string
+	LeaseID         *string
+	Range           *string
+	EncryptionScope *string
+}
+
+type PutBlockFromURLResponse struct {
+	ContentMD5   string
+	HttpResponse *http.Response
+}
+
+// PutBlockFromURL creates a new block to be committed as part of a blob where the contents are read from a URL
+func (c Client) PutBlockFromURL(ctx context.Context, containerName, blobName string, input PutBlockFromURLInput) (result PutBlockFromURLResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	if input.BlockID == "" {
+		err = fmt.Errorf("`input.BlockID` cannot be an empty string")
+		return
+	}
+
+	if input.CopySource == "" {
+		err = fmt.Errorf("`input.CopySource` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: putBlockUrlOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.ContentMD5 = resp.Header.Get("Content-MD5")
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type putBlockUrlOptions struct {
+	input PutBlockFromURLInput
+}
+
+func (p putBlockUrlOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	headers.Append("x-ms-copy-source", p.input.CopySource)
+
+	if p.input.ContentMD5 != nil {
+		headers.Append("x-ms-source-content-md5", *p.input.ContentMD5)
+	}
+	if p.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *p.input.LeaseID)
+	}
+	if p.input.Range != nil {
+		headers.Append("x-ms-source-range", *p.input.Range)
+	}
+	if p.input.EncryptionScope != nil {
+		headers.Append("x-ms-encryption-scope", *p.input.EncryptionScope)
+	}
+	return headers
+}
+
+func (p putBlockUrlOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (p putBlockUrlOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "block")
+	out.Append("blockid", p.input.BlockID)
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/put_page_blob.go
+++ b/storage/2026-02-06/blob/blobs/put_page_blob.go
@@ -1,0 +1,155 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type PutPageBlobInput struct {
+	CacheControl       *string
+	ContentDisposition *string
+	ContentEncoding    *string
+	ContentLanguage    *string
+	ContentMD5         *string
+	ContentType        *string
+	LeaseID            *string
+	EncryptionScope    *string
+	MetaData           map[string]string
+
+	BlobContentLengthBytes int64
+	BlobSequenceNumber     *int64
+	AccessTier             *AccessTier
+}
+
+type PutPageBlobResponse struct {
+	HttpResponse *http.Response
+}
+
+// PutPageBlob is a wrapper around the Put API call (with a stricter input object)
+// which creates a new block blob, or updates the content of an existing page blob.
+func (c Client) PutPageBlob(ctx context.Context, containerName, blobName string, input PutPageBlobInput) (result PutPageBlobResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	if input.BlobContentLengthBytes == 0 || input.BlobContentLengthBytes%512 != 0 {
+		err = fmt.Errorf("`input.BlobContentLengthBytes` must be aligned to a 512-byte boundary")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: putPageBlobOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type putPageBlobOptions struct {
+	input PutPageBlobInput
+}
+
+func (p putPageBlobOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	headers.Append("x-ms-blob-type", string(PageBlob))
+
+	// For a page blob or an page blob, the value of this header must be set to zero,
+	// as Put Blob is used only to initialize the blob
+	headers.Append("Content-Length", "0")
+
+	// This header specifies the maximum size for the page blob, up to 8 TB.
+	// The page blob size must be aligned to a 512-byte boundary.
+	headers.Append("x-ms-blob-content-length", strconv.Itoa(int(p.input.BlobContentLengthBytes)))
+
+	if p.input.AccessTier != nil {
+		headers.Append("x-ms-access-tier", string(*p.input.AccessTier))
+	}
+
+	if p.input.BlobSequenceNumber != nil {
+		headers.Append("x-ms-blob-sequence-number", strconv.Itoa(int(*p.input.BlobSequenceNumber)))
+	}
+
+	if p.input.CacheControl != nil {
+		headers.Append("x-ms-blob-cache-control", *p.input.CacheControl)
+	}
+
+	if p.input.ContentDisposition != nil {
+		headers.Append("x-ms-blob-content-disposition", *p.input.ContentDisposition)
+	}
+
+	if p.input.ContentEncoding != nil {
+		headers.Append("x-ms-blob-content-encoding", *p.input.ContentEncoding)
+	}
+
+	if p.input.ContentLanguage != nil {
+		headers.Append("x-ms-blob-content-language", *p.input.ContentLanguage)
+	}
+
+	if p.input.ContentMD5 != nil {
+		headers.Append("x-ms-blob-content-md5", *p.input.ContentMD5)
+	}
+
+	if p.input.ContentType != nil {
+		headers.Append("x-ms-blob-content-type", *p.input.ContentType)
+	}
+
+	if p.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *p.input.LeaseID)
+	}
+
+	if p.input.EncryptionScope != nil {
+		headers.Append("x-ms-encryption-scope", *p.input.EncryptionScope)
+	}
+
+	headers.Merge(metadata.SetMetaDataHeaders(p.input.MetaData))
+	return headers
+}
+
+func (p putPageBlobOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (p putPageBlobOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/blob/blobs/put_page_clear.go
+++ b/storage/2026-02-06/blob/blobs/put_page_clear.go
@@ -1,0 +1,110 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type PutPageClearInput struct {
+	StartByte int64
+	EndByte   int64
+
+	LeaseID         *string
+	EncryptionScope *string
+}
+
+type PutPageClearResponse struct {
+	HttpResponse *http.Response
+}
+
+// PutPageClear clears a range of pages within a page blob.
+func (c Client) PutPageClear(ctx context.Context, containerName, blobName string, input PutPageClearInput) (result PutPageClearResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	if input.StartByte < 0 {
+		err = fmt.Errorf("`input.StartByte` must be greater than or equal to 0")
+		return
+	}
+
+	if input.EndByte <= 0 {
+		err = fmt.Errorf("`input.EndByte` must be greater than 0")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: putPageClearOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type putPageClearOptions struct {
+	input PutPageClearInput
+}
+
+func (p putPageClearOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	headers.Append("x-ms-page-write", "clear")
+	headers.Append("x-ms-range", fmt.Sprintf("bytes=%d-%d", p.input.StartByte, p.input.EndByte))
+
+	if p.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *p.input.LeaseID)
+	}
+	if p.input.EncryptionScope != nil {
+		headers.Append("x-ms-encryption-scope", *p.input.EncryptionScope)
+	}
+
+	return headers
+}
+
+func (p putPageClearOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (p putPageClearOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "page")
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/put_page_update.go
+++ b/storage/2026-02-06/blob/blobs/put_page_update.go
@@ -1,0 +1,173 @@
+package blobs
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type PutPageUpdateInput struct {
+	StartByte int64
+	EndByte   int64
+	Content   []byte
+
+	IfSequenceNumberEQ *string
+	IfSequenceNumberLE *string
+	IfSequenceNumberLT *string
+	IfModifiedSince    *string
+	IfUnmodifiedSince  *string
+	IfMatch            *string
+	IfNoneMatch        *string
+	LeaseID            *string
+	EncryptionScope    *string
+}
+
+type PutPageUpdateResponse struct {
+	HttpResponse *http.Response
+
+	BlobSequenceNumber string
+	ContentMD5         string
+	LastModified       string
+}
+
+// PutPageUpdate writes a range of pages to a page blob.
+func (c Client) PutPageUpdate(ctx context.Context, containerName, blobName string, input PutPageUpdateInput) (result PutPageUpdateResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	if input.StartByte < 0 {
+		err = fmt.Errorf("`input.StartByte` must be greater than or equal to 0")
+		return
+	}
+
+	if input.EndByte <= 0 {
+		err = fmt.Errorf("`input.EndByte` must be greater than 0")
+		return
+	}
+
+	expectedSize := (input.EndByte - input.StartByte) + 1
+	actualSize := int64(len(input.Content))
+	if expectedSize != actualSize {
+		err = fmt.Errorf(fmt.Sprintf("Content Size was defined as %d but got %d.", expectedSize, actualSize))
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: putPageUpdateOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	// this is needed to avoid `Content-Length: 0` in the request
+	req.Body = io.NopCloser(bytes.NewReader(input.Content))
+	req.ContentLength = int64(len(input.Content))
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.BlobSequenceNumber = resp.Header.Get("x-ms-blob-sequence-number")
+				result.ContentMD5 = resp.Header.Get("Content-MD5")
+				result.LastModified = resp.Header.Get("Last-Modified")
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type putPageUpdateOptions struct {
+	input PutPageUpdateInput
+}
+
+func (p putPageUpdateOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("x-ms-page-write", "update")
+	headers.Append("x-ms-range", fmt.Sprintf("bytes=%d-%d", p.input.StartByte, p.input.EndByte))
+	headers.Append("Content-Length", strconv.Itoa(len(p.input.Content)))
+
+	if p.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *p.input.LeaseID)
+	}
+
+	if p.input.EncryptionScope != nil {
+		headers.Append("x-ms-encryption-scope", *p.input.EncryptionScope)
+	}
+
+	if p.input.IfSequenceNumberEQ != nil {
+		headers.Append("x-ms-if-sequence-number-eq", *p.input.IfSequenceNumberEQ)
+	}
+
+	if p.input.IfSequenceNumberLE != nil {
+		headers.Append("x-ms-if-sequence-number-le", *p.input.IfSequenceNumberLE)
+	}
+
+	if p.input.IfSequenceNumberLT != nil {
+		headers.Append("x-ms-if-sequence-number-lt", *p.input.IfSequenceNumberLT)
+	}
+
+	if p.input.IfModifiedSince != nil {
+		headers.Append("If-Modified-Since", *p.input.IfModifiedSince)
+	}
+
+	if p.input.IfUnmodifiedSince != nil {
+		headers.Append("If-Unmodified-Since", *p.input.IfUnmodifiedSince)
+	}
+
+	if p.input.IfMatch != nil {
+		headers.Append("If-Match", *p.input.IfMatch)
+	}
+
+	if p.input.IfNoneMatch != nil {
+		headers.Append("If-None-Match", *p.input.IfNoneMatch)
+	}
+
+	return headers
+}
+
+func (p putPageUpdateOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (p putPageUpdateOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "page")
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/resource_id.go
+++ b/storage/2026-02-06/blob/blobs/resource_id.go
@@ -1,0 +1,83 @@
+package blobs
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+// TODO: update this to implement `resourceids.ResourceId` once
+// https://github.com/hashicorp/go-azure-helpers/issues/187 is fixed
+var _ resourceids.Id = BlobId{}
+
+type BlobId struct {
+	// AccountId specifies the ID of the Storage Account where this Blob exists.
+	AccountId accounts.AccountId
+
+	// ContainerName specifies the name of the Container within this Storage Account where this
+	// Blob exists.
+	ContainerName string
+
+	// BlobName specifies the name of this Blob.
+	BlobName string
+}
+
+func NewBlobID(accountId accounts.AccountId, containerName, blobName string) BlobId {
+	return BlobId{
+		AccountId:     accountId,
+		ContainerName: containerName,
+		BlobName:      blobName,
+	}
+}
+
+func (b BlobId) ID() string {
+	return fmt.Sprintf("%s/%s/%s", b.AccountId.ID(), b.ContainerName, b.BlobName)
+}
+
+func (b BlobId) String() string {
+	components := []string{
+		fmt.Sprintf("Account %q", b.AccountId.String()),
+		fmt.Sprintf("Container Name %q", b.ContainerName),
+	}
+	return fmt.Sprintf("Blob %q (%s)", b.BlobName, strings.Join(components, " / "))
+}
+
+// ParseBlobID parses `input` into a Blob ID using a known `domainSuffix`
+func ParseBlobID(input, domainSuffix string) (*BlobId, error) {
+	// example: https://foo.blob.core.windows.net/Bar/example.vhd
+	if input == "" {
+		return nil, fmt.Errorf("`input` was empty")
+	}
+
+	account, err := accounts.ParseAccountID(input, domainSuffix)
+	if err != nil {
+		return nil, fmt.Errorf("parsing account %q: %+v", input, err)
+	}
+
+	if account.SubDomainType != accounts.BlobSubDomainType {
+		return nil, fmt.Errorf("expected the subdomain type to be %q but got %q", string(accounts.BlobSubDomainType), string(account.SubDomainType))
+	}
+
+	uri, err := url.Parse(input)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q as a uri: %+v", input, err)
+	}
+
+	path := strings.TrimPrefix(uri.Path, "/")
+	segments := strings.Split(path, "/")
+	if len(segments) < 2 {
+		return nil, fmt.Errorf("expected the path to contain at least 2 segments but got %d", len(segments))
+	}
+
+	containerName := segments[0]
+	blobName := strings.TrimPrefix(path, containerName)
+	blobName = strings.TrimPrefix(blobName, "/")
+	return &BlobId{
+		AccountId:     *account,
+		ContainerName: containerName,
+		BlobName:      blobName,
+	}, nil
+}

--- a/storage/2026-02-06/blob/blobs/resource_id_test.go
+++ b/storage/2026-02-06/blob/blobs/resource_id_test.go
@@ -1,0 +1,233 @@
+package blobs
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+func TestParseBlobIDStandard(t *testing.T) {
+	input := "https://example1.blob.core.windows.net/container1/blob1.vhd"
+	expected := BlobId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.BlobSubDomainType,
+			DomainSuffix:  "core.windows.net",
+		},
+		ContainerName: "container1",
+		BlobName:      "blob1.vhd",
+	}
+	actual, err := ParseBlobID(input, "core.windows.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if actual.ContainerName != expected.ContainerName {
+		t.Fatalf("expected ContainerName to be %q but got %q", expected.ContainerName, actual.ContainerName)
+	}
+	if actual.BlobName != expected.BlobName {
+		t.Fatalf("expected BlobName to be %q but got %q", expected.BlobName, actual.BlobName)
+	}
+}
+
+func TestParseNestedBlobIDStandard(t *testing.T) {
+	input := "https://example1.blob.core.windows.net/container1/more/deeply/nested/blob1.vhd"
+	expected := BlobId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.BlobSubDomainType,
+			DomainSuffix:  "core.windows.net",
+		},
+		ContainerName: "container1",
+		BlobName:      "more/deeply/nested/blob1.vhd",
+	}
+	actual, err := ParseBlobID(input, "core.windows.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if actual.ContainerName != expected.ContainerName {
+		t.Fatalf("expected ContainerName to be %q but got %q", expected.ContainerName, actual.ContainerName)
+	}
+	if actual.BlobName != expected.BlobName {
+		t.Fatalf("expected BlobName to be %q but got %q", expected.BlobName, actual.BlobName)
+	}
+}
+
+func TestParseInvalidBlobIDStandard(t *testing.T) {
+	input := "https://example1.blob.core.windows.net/blobby.vhd"
+	actual, err := ParseBlobID(input, "core.windows.net")
+	if err == nil {
+		if actual != nil {
+			t.Fatalf("expected an error but got: %#v", *actual)
+		} else {
+			t.Fatalf("expected an error but got no error and a nil result")
+		}
+	}
+	if err.Error() != "expected the path to contain at least 2 segments but got 1" {
+		t.Fatalf("unexpected error received: %+v", err)
+	}
+}
+
+func TestParseBlobIDInADNSZone(t *testing.T) {
+	input := "https://example1.zone1.blob.storage.azure.net/container1/blob1.vhd"
+	expected := BlobId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.BlobSubDomainType,
+			DomainSuffix:  "storage.azure.net",
+			ZoneName:      pointer.To("zone1"),
+		},
+		ContainerName: "container1",
+		BlobName:      "blob1.vhd",
+	}
+	actual, err := ParseBlobID(input, "storage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if pointer.From(actual.AccountId.ZoneName) != pointer.From(expected.AccountId.ZoneName) {
+		t.Fatalf("expected ZoneName to be %q but got %q", pointer.From(expected.AccountId.ZoneName), pointer.From(actual.AccountId.ZoneName))
+	}
+	if actual.ContainerName != expected.ContainerName {
+		t.Fatalf("expected ContainerName to be %q but got %q", expected.ContainerName, actual.ContainerName)
+	}
+	if actual.BlobName != expected.BlobName {
+		t.Fatalf("expected BlobName to be %q but got %q", expected.BlobName, actual.BlobName)
+	}
+}
+
+func TestParseBlobIDInAnEdgeZone(t *testing.T) {
+	input := "https://example1.blob.zone1.edgestorage.azure.net/container1/blob1.vhd"
+	expected := BlobId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.BlobSubDomainType,
+			DomainSuffix:  "edgestorage.azure.net",
+			ZoneName:      pointer.To("zone1"),
+			IsEdgeZone:    true,
+		},
+		ContainerName: "container1",
+		BlobName:      "blob1.vhd",
+	}
+	actual, err := ParseBlobID(input, "edgestorage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if pointer.From(actual.AccountId.ZoneName) != pointer.From(expected.AccountId.ZoneName) {
+		t.Fatalf("expected ZoneName to be %q but got %q", pointer.From(expected.AccountId.ZoneName), pointer.From(actual.AccountId.ZoneName))
+	}
+	if !actual.AccountId.IsEdgeZone {
+		t.Fatalf("expected the Account to be in an Edge Zone but it wasn't")
+	}
+	if actual.ContainerName != expected.ContainerName {
+		t.Fatalf("expected ContainerName to be %q but got %q", expected.ContainerName, actual.ContainerName)
+	}
+	if actual.BlobName != expected.BlobName {
+		t.Fatalf("expected BlobName to be %q but got %q", expected.BlobName, actual.BlobName)
+	}
+}
+
+func TestFormatBlobIDStandard(t *testing.T) {
+	actual := BlobId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.BlobSubDomainType,
+			DomainSuffix:  "core.windows.net",
+			IsEdgeZone:    false,
+		},
+		ContainerName: "container1",
+		BlobName:      "somefile.vhd",
+	}.ID()
+	expected := "https://example1.blob.core.windows.net/container1/somefile.vhd"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatNestedBlobIDStandard(t *testing.T) {
+	actual := BlobId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.BlobSubDomainType,
+			DomainSuffix:  "core.windows.net",
+			IsEdgeZone:    false,
+		},
+		ContainerName: "container1",
+		BlobName:      "more/deeply/nested/somefile.vhd",
+	}.ID()
+	expected := "https://example1.blob.core.windows.net/container1/more/deeply/nested/somefile.vhd"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatBlobIDInDNSZone(t *testing.T) {
+	actual := BlobId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			ZoneName:      pointer.To("zone2"),
+			SubDomainType: accounts.BlobSubDomainType,
+			DomainSuffix:  "storage.azure.net",
+			IsEdgeZone:    false,
+		},
+		ContainerName: "container1",
+		BlobName:      "somefile.vhd",
+	}.ID()
+	expected := "https://example1.zone2.blob.storage.azure.net/container1/somefile.vhd"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatBlobIDInEdgeZone(t *testing.T) {
+	actual := BlobId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			ZoneName:      pointer.To("zone2"),
+			SubDomainType: accounts.BlobSubDomainType,
+			DomainSuffix:  "edgestorage.azure.net",
+			IsEdgeZone:    true,
+		},
+		ContainerName: "container1",
+		BlobName:      "somefile.vhd",
+	}.ID()
+	expected := "https://example1.blob.zone2.edgestorage.azure.net/container1/somefile.vhd"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}

--- a/storage/2026-02-06/blob/blobs/set_tier.go
+++ b/storage/2026-02-06/blob/blobs/set_tier.go
@@ -1,0 +1,87 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type SetTierInput struct {
+	Tier AccessTier
+}
+
+type SetTierResponse struct {
+	HttpResponse *http.Response
+}
+
+// SetTier sets the tier on a blob.
+func (c Client) SetTier(ctx context.Context, containerName, blobName string, input SetTierInput) (result SetTierResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+			http.StatusAccepted,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: setTierOptions{
+			tier: input.Tier,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type setTierOptions struct {
+	tier AccessTier
+}
+
+func (s setTierOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("x-ms-access-tier", string(s.tier))
+	return headers
+}
+
+func (s setTierOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (s setTierOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "tier")
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/snapshot.go
+++ b/storage/2026-02-06/blob/blobs/snapshot.go
@@ -1,0 +1,160 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type SnapshotInput struct {
+	// The ID of the Lease
+	// This must be specified if a Lease is present on the Blob, else a 403 is returned
+	LeaseID *string
+
+	// The encryption scope to set for the request content.
+	EncryptionScope *string
+
+	// MetaData is a user-defined name-value pair associated with the blob.
+	// If no name-value pairs are specified, the operation will copy the base blob metadata to the snapshot.
+	// If one or more name-value pairs are specified, the snapshot is created with the specified metadata,
+	// and metadata is not copied from the base blob.
+	MetaData map[string]string
+
+	// A DateTime value which will only snapshot the blob if it has been modified since the specified date/time
+	// If the base blob has not been modified, the Blob service returns status code 412 (Precondition Failed).
+	IfModifiedSince *string
+
+	// A DateTime value which will only snapshot the blob if it has not been modified since the specified date/time
+	// If the base blob has been modified, the Blob service returns status code 412 (Precondition Failed).
+	IfUnmodifiedSince *string
+
+	// An ETag value to snapshot the blob only if its ETag value matches the value specified.
+	// If the values do not match, the Blob service returns status code 412 (Precondition Failed).
+	IfMatch *string
+
+	// An ETag value for this conditional header to snapshot the blob only if its ETag value
+	// does not match the value specified.
+	// If the values are identical, the Blob service returns status code 412 (Precondition Failed).
+	IfNoneMatch *string
+}
+
+type SnapshotResponse struct {
+	HttpResponse *http.Response
+
+	// The ETag of the snapshot
+	ETag string
+
+	// A DateTime value that uniquely identifies the snapshot.
+	// The value of this header indicates the snapshot version,
+	// and may be used in subsequent requests to access the snapshot.
+	SnapshotDateTime string
+}
+
+// Snapshot captures a Snapshot of a given Blob
+func (c Client) Snapshot(ctx context.Context, containerName, blobName string, input SnapshotInput) (result SnapshotResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	if err = metadata.Validate(input.MetaData); err != nil {
+		err = fmt.Errorf(fmt.Sprintf("`input.MetaData` is not valid: %s.", err))
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: snapshotOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.ETag = resp.Header.Get("ETag")
+				result.SnapshotDateTime = resp.Header.Get("x-ms-snapshot")
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type snapshotOptions struct {
+	input SnapshotInput
+}
+
+func (s snapshotOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	if s.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *s.input.LeaseID)
+	}
+
+	if s.input.EncryptionScope != nil {
+		headers.Append("x-ms-encryption-scope", *s.input.EncryptionScope)
+	}
+
+	if s.input.IfModifiedSince != nil {
+		headers.Append("If-Modified-Since", *s.input.IfModifiedSince)
+	}
+
+	if s.input.IfUnmodifiedSince != nil {
+		headers.Append("If-Unmodified-Since", *s.input.IfUnmodifiedSince)
+	}
+
+	if s.input.IfMatch != nil {
+		headers.Append("If-Match", *s.input.IfMatch)
+	}
+
+	if s.input.IfNoneMatch != nil {
+		headers.Append("If-None-Match", *s.input.IfNoneMatch)
+	}
+
+	headers.Merge(metadata.SetMetaDataHeaders(s.input.MetaData))
+	return headers
+}
+
+func (s snapshotOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (s snapshotOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "snapshot")
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/snapshot_get_properties.go
+++ b/storage/2026-02-06/blob/blobs/snapshot_get_properties.go
@@ -1,0 +1,170 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type GetSnapshotPropertiesInput struct {
+	// The ID of the Lease
+	// This must be specified if a Lease is present on the Blob, else a 403 is returned
+	LeaseID *string
+
+	// The ID of the Snapshot which should be retrieved
+	SnapshotID string
+}
+
+// GetSnapshotProperties returns all user-defined metadata, standard HTTP properties, and system properties for
+// the specified snapshot of a blob
+func (c Client) GetSnapshotProperties(ctx context.Context, containerName, blobName string, input GetSnapshotPropertiesInput) (result GetPropertiesResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	if input.SnapshotID == "" {
+		err = fmt.Errorf("`input.SnapshotID` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodHead,
+		OptionsObject: snapshotGetPropertiesOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.AccessTier = AccessTier(resp.Header.Get("x-ms-access-tier"))
+				result.AccessTierChangeTime = resp.Header.Get("x-ms-access-tier-change-time")
+				result.ArchiveStatus = ArchiveStatus(resp.Header.Get("x-ms-archive-status"))
+				result.BlobCommittedBlockCount = resp.Header.Get("x-ms-blob-committed-block-count")
+				result.BlobSequenceNumber = resp.Header.Get("x-ms-blob-sequence-number")
+				result.BlobType = BlobType(resp.Header.Get("x-ms-blob-type"))
+				result.CacheControl = resp.Header.Get("Cache-Control")
+				result.ContentDisposition = resp.Header.Get("Content-Disposition")
+				result.ContentEncoding = resp.Header.Get("Content-Encoding")
+				result.ContentLanguage = resp.Header.Get("Content-Language")
+				result.ContentMD5 = resp.Header.Get("Content-MD5")
+				result.ContentType = resp.Header.Get("Content-Type")
+				result.CopyCompletionTime = resp.Header.Get("x-ms-copy-completion-time")
+				result.CopyDestinationSnapshot = resp.Header.Get("x-ms-copy-destination-snapshot")
+				result.CopyID = resp.Header.Get("x-ms-copy-id")
+				result.CopyProgress = resp.Header.Get("x-ms-copy-progress")
+				result.CopySource = resp.Header.Get("x-ms-copy-source")
+				result.CopyStatus = CopyStatus(resp.Header.Get("x-ms-copy-status"))
+				result.CopyStatusDescription = resp.Header.Get("x-ms-copy-status-description")
+				result.CreationTime = resp.Header.Get("x-ms-creation-time")
+				result.ETag = resp.Header.Get("Etag")
+				result.LastModified = resp.Header.Get("Last-Modified")
+				result.LeaseDuration = LeaseDuration(resp.Header.Get("x-ms-lease-duration"))
+				result.LeaseState = LeaseState(resp.Header.Get("x-ms-lease-state"))
+				result.LeaseStatus = LeaseStatus(resp.Header.Get("x-ms-lease-status"))
+				result.MetaData = metadata.ParseFromHeaders(resp.Header)
+
+				if v := resp.Header.Get("Content-Length"); v != "" {
+					i, innerErr := strconv.Atoi(v)
+					if innerErr != nil {
+						err = fmt.Errorf("parsing `Content-Length` header value %q: %+v", v, innerErr)
+					}
+
+					result.ContentLength = int64(i)
+				}
+
+				if v := resp.Header.Get("x-ms-access-tier-inferred"); v != "" {
+					b, innerErr := strconv.ParseBool(v)
+					if innerErr != nil {
+						err = fmt.Errorf("parsing `x-ms-access-tier-inferred` header value %q: %+v", v, innerErr)
+						return
+					}
+
+					result.AccessTierInferred = b
+				}
+
+				if v := resp.Header.Get("x-ms-incremental-copy"); v != "" {
+					b, innerErr := strconv.ParseBool(v)
+					if innerErr != nil {
+						err = fmt.Errorf("parsing `x-ms-incremental-copy` header value %q: %+v", v, innerErr)
+						return
+					}
+
+					result.IncrementalCopy = b
+				}
+
+				if v := resp.Header.Get("x-ms-server-encrypted"); v != "" {
+					b, innerErr := strconv.ParseBool(v)
+					if innerErr != nil {
+						err = fmt.Errorf("parsing `\"x-ms-server-encrypted` header value %q: %+v", v, innerErr)
+						return
+					}
+
+					result.ServerEncrypted = b
+				}
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	if result.HttpResponse != nil {
+	}
+
+	return
+}
+
+type snapshotGetPropertiesOptions struct {
+	input GetSnapshotPropertiesInput
+}
+
+func (s snapshotGetPropertiesOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	if s.input.LeaseID != nil {
+		headers.Append("x-ms-lease-id", *s.input.LeaseID)
+	}
+	return headers
+}
+
+func (s snapshotGetPropertiesOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (s snapshotGetPropertiesOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("snapshot", s.input.SnapshotID)
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/snapshot_test.go
+++ b/storage/2026-02-06/blob/blobs/snapshot_test.go
@@ -1,0 +1,176 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2020-08-04/blob/containers"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+func TestSnapshotLifecycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	containerName := fmt.Sprintf("cont-%d", testhelpers.RandomInt())
+	fileName := "example.txt"
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindBlobStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+
+	containersClient, err := containers.NewWithBaseUri(fmt.Sprintf("https://%s.blob.%s", testData.StorageAccountName, *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err := client.PrepareWithSharedKeyAuth(containersClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	_, err = containersClient.Create(ctx, containerName, containers.CreateInput{})
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error creating: %s", err))
+	}
+	defer containersClient.Delete(ctx, containerName)
+
+	blobClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.blob.%s", testData.StorageAccountName, *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err := client.PrepareWithSharedKeyAuth(blobClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	t.Logf("[DEBUG] Copying file to Blob Storage..")
+	copyInput := CopyInput{
+		CopySource: "http://releases.ubuntu.com/14.04/ubuntu-14.04.6-desktop-amd64.iso",
+	}
+
+	if err := blobClient.CopyAndWait(ctx, containerName, fileName, copyInput); err != nil {
+		t.Fatalf("Error copying: %s", err)
+	}
+
+	t.Logf("[DEBUG] First Snapshot..")
+	firstSnapshot, err := blobClient.Snapshot(ctx, containerName, fileName, SnapshotInput{})
+	if err != nil {
+		t.Fatalf("Error taking first snapshot: %s", err)
+	}
+	t.Logf("[DEBUG] First Snapshot ID: %q", firstSnapshot.SnapshotDateTime)
+
+	t.Log("[DEBUG] Waiting 2 seconds..")
+	time.Sleep(2 * time.Second)
+
+	t.Logf("[DEBUG] Second Snapshot..")
+	secondSnapshot, err := blobClient.Snapshot(ctx, containerName, fileName, SnapshotInput{
+		MetaData: map[string]string{
+			"hello": "world",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Error taking Second snapshot: %s", err)
+	}
+	t.Logf("[DEBUG] Second Snapshot ID: %q", secondSnapshot.SnapshotDateTime)
+
+	t.Logf("[DEBUG] Leasing the Blob..")
+	leaseDetails, err := blobClient.AcquireLease(ctx, containerName, fileName, AcquireLeaseInput{
+		// infinite
+		LeaseDuration: -1,
+	})
+	if err != nil {
+		t.Fatalf("Error leasing Blob: %s", err)
+	}
+	t.Logf("[DEBUG] Lease ID: %q", leaseDetails.LeaseID)
+
+	t.Logf("[DEBUG] Third Snapshot..")
+	thirdSnapshot, err := blobClient.Snapshot(ctx, containerName, fileName, SnapshotInput{
+		LeaseID: &leaseDetails.LeaseID,
+	})
+	if err != nil {
+		t.Fatalf("Error taking Third snapshot: %s", err)
+	}
+	t.Logf("[DEBUG] Third Snapshot ID: %q", thirdSnapshot.SnapshotDateTime)
+
+	t.Logf("[DEBUG] Releasing Lease..")
+	if _, err := blobClient.ReleaseLease(ctx, containerName, fileName, ReleaseLeaseInput{leaseDetails.LeaseID}); err != nil {
+		t.Fatalf("Error releasing Lease: %s", err)
+	}
+
+	// get the properties from the blob, which should include the LastModifiedDate
+	t.Logf("[DEBUG] Retrieving Properties for Blob")
+	props, err := blobClient.GetProperties(ctx, containerName, fileName, GetPropertiesInput{})
+	if err != nil {
+		t.Fatalf("Error getting properties: %s", err)
+	}
+
+	// confirm that the If-Modified-None returns an error
+	t.Logf("[DEBUG] Third Snapshot..")
+	fourthSnapshot, err := blobClient.Snapshot(ctx, containerName, fileName, SnapshotInput{
+		LeaseID:         &leaseDetails.LeaseID,
+		IfModifiedSince: &props.LastModified,
+	})
+	if err == nil {
+		t.Fatalf("Expected an error but didn't get one")
+	}
+	if fourthSnapshot.HttpResponse.StatusCode != http.StatusPreconditionFailed {
+		t.Fatalf("Expected the status code to be Precondition Failed but got: %d", fourthSnapshot.HttpResponse.StatusCode)
+	}
+
+	t.Logf("[DEBUG] Retrieving the Second Snapshot Properties..")
+	getSecondSnapshotInput := GetSnapshotPropertiesInput{
+		SnapshotID: secondSnapshot.SnapshotDateTime,
+	}
+	if _, err := blobClient.GetSnapshotProperties(ctx, containerName, fileName, getSecondSnapshotInput); err != nil {
+		t.Fatalf("Error retrieving properties for the second snapshot: %s", err)
+	}
+
+	t.Logf("[DEBUG] Deleting the Second Snapshot..")
+	deleteSnapshotInput := DeleteSnapshotInput{
+		SnapshotDateTime: secondSnapshot.SnapshotDateTime,
+	}
+	if _, err := blobClient.DeleteSnapshot(ctx, containerName, fileName, deleteSnapshotInput); err != nil {
+		t.Fatalf("Error deleting snapshot: %s", err)
+	}
+
+	t.Logf("[DEBUG] Re-Retrieving the Second Snapshot Properties..")
+	secondSnapshotProps, err := blobClient.GetSnapshotProperties(ctx, containerName, fileName, getSecondSnapshotInput)
+	if err == nil {
+		t.Fatalf("Expected an error retrieving the snapshot but got none")
+	}
+	if secondSnapshotProps.HttpResponse.StatusCode != http.StatusNotFound {
+		t.Fatalf("Expected the status code to be %d but got %q", http.StatusNoContent, secondSnapshotProps.HttpResponse.StatusCode)
+	}
+
+	t.Logf("[DEBUG] Deleting all the snapshots..")
+	if _, err := blobClient.DeleteSnapshots(ctx, containerName, fileName, DeleteSnapshotsInput{}); err != nil {
+		t.Fatalf("Error deleting snapshots: %s", err)
+	}
+
+	t.Logf("[DEBUG] Deleting the Blob..")
+	deleteInput := DeleteInput{
+		DeleteSnapshots: false,
+	}
+	if _, err := blobClient.Delete(ctx, containerName, fileName, deleteInput); err != nil {
+		t.Fatalf("Error deleting Blob: %s", err)
+	}
+}

--- a/storage/2026-02-06/blob/blobs/snapshot_test.go
+++ b/storage/2026-02-06/blob/blobs/snapshot_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
-	"github.com/jackofallops/giovanni/storage/2020-08-04/blob/containers"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/containers"
 	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
 )
 

--- a/storage/2026-02-06/blob/blobs/undelete.go
+++ b/storage/2026-02-06/blob/blobs/undelete.go
@@ -1,0 +1,76 @@
+package blobs
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type UndeleteResponse struct {
+	HttpResponse *http.Response
+}
+
+// Undelete restores the contents and metadata of soft deleted blob and any associated soft deleted snapshots.
+func (c Client) Undelete(ctx context.Context, containerName, blobName string) (result UndeleteResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(containerName) != containerName {
+		err = fmt.Errorf("`containerName` must be a lower-cased string")
+		return
+	}
+
+	if blobName == "" {
+		err = fmt.Errorf("`blobName` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodPut,
+		OptionsObject: undeleteOptions{},
+		Path:          fmt.Sprintf("/%s/%s", containerName, blobName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type undeleteOptions struct{}
+
+func (u undeleteOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (u undeleteOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (u undeleteOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "undelete")
+	return out
+}

--- a/storage/2026-02-06/blob/blobs/version.go
+++ b/storage/2026-02-06/blob/blobs/version.go
@@ -1,0 +1,5 @@
+package blobs
+
+// APIVersion is the version of the API used for all Storage API Operations
+const apiVersion = "2026-02-06"
+const componentName = "blob/blobs"

--- a/storage/2026-02-06/blob/containers/README.md
+++ b/storage/2026-02-06/blob/containers/README.md
@@ -1,0 +1,52 @@
+## Blob Storage Container SDK for API version 2026-02-06
+
+This package allows you to interact with the Containers Blob Storage API
+
+### Supported Authorizers
+
+* Azure Active Directory (for the Resource Endpoint `https://storage.azure.com`)
+* SharedKeyLite (Blob, File & Queue)
+
+Note: when using the `ListBlobs` operation, only `SharedKeyLite` authentication is supported.
+
+### Example Usage
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/containers"
+)
+
+func Example() error {
+	accountName := "storageaccount1"
+    storageAccountKey := "ABC123...."
+    containerName := "mycontainer"
+	domainSuffix := "core.windows.net"
+
+    containersClient, err := containers.NewWithBaseUri(fmt.Sprintf("https://%s.blob.%s", accountName, domainSuffix))
+	if err != nil {
+		return fmt.Errorf("building client for environment: %+v", err)
+	}
+
+	auth, err := auth.NewSharedKeyAuthorizer(accountName, storageAccountKey, auth.SharedKey)
+	if err != nil {
+		return fmt.Errorf("building SharedKey authorizer: %+v", err)
+	}
+	containersClient.Client.SetAuthorizer(auth)
+    
+    ctx := context.TODO()
+    createInput := containers.CreateInput{
+        AccessLevel: containers.Private,
+    }
+    if _, err := containersClient.Create(ctx, containerName, createInput); err != nil {
+        return fmt.Errorf("Error creating Container: %s", err)
+    }
+    
+    return nil 
+}
+```

--- a/storage/2026-02-06/blob/containers/api.go
+++ b/storage/2026-02-06/blob/containers/api.go
@@ -1,0 +1,20 @@
+package containers
+
+import (
+	"context"
+)
+
+type StorageContainer interface {
+	Create(ctx context.Context, containerName string, input CreateInput) (CreateResponse, error)
+	Delete(ctx context.Context, containerName string) (DeleteResponse, error)
+	GetProperties(ctx context.Context, containerName string, input GetPropertiesInput) (GetPropertiesResponse, error)
+	AcquireLease(ctx context.Context, containerName string, input AcquireLeaseInput) (AcquireLeaseResponse, error)
+	BreakLease(ctx context.Context, containerName string, input BreakLeaseInput) (BreakLeaseResponse, error)
+	ChangeLease(ctx context.Context, containerName string, input ChangeLeaseInput) (ChangeLeaseResponse, error)
+	ReleaseLease(ctx context.Context, containerName string, input ReleaseLeaseInput) (ReleaseLeaseResponse, error)
+	RenewLease(ctx context.Context, containerName string, input RenewLeaseInput) (RenewLeaseResponse, error)
+	ListBlobs(ctx context.Context, containerName string, input ListBlobsInput) (ListBlobsResponse, error)
+	GetResourceManagerResourceID(subscriptionID, resourceGroup, accountName, containerName string) string
+	SetAccessControl(ctx context.Context, containerName string, input SetAccessControlInput) (SetAccessControlResponse, error)
+	SetMetaData(ctx context.Context, containerName string, metaData SetMetaDataInput) (SetMetaDataResponse, error)
+}

--- a/storage/2026-02-06/blob/containers/client.go
+++ b/storage/2026-02-06/blob/containers/client.go
@@ -1,0 +1,22 @@
+package containers
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/dataplane/storage"
+)
+
+// Client is the base client for Blob Storage Containers.
+type Client struct {
+	Client *storage.Client
+}
+
+func NewWithBaseUri(baseUri string) (*Client, error) {
+	baseClient, err := storage.NewStorageClient(baseUri, componentName, apiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("building base client: %+v", err)
+	}
+	return &Client{
+		Client: baseClient,
+	}, nil
+}

--- a/storage/2026-02-06/blob/containers/create.go
+++ b/storage/2026-02-06/blob/containers/create.go
@@ -1,0 +1,135 @@
+package containers
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type CreateInput struct {
+	// Specifies whether data in the container may be accessed publicly and the level of access
+	AccessLevel AccessLevel
+
+	// The encryption scope to set as the default on the container.
+	DefaultEncryptionScope string
+
+	// Setting this to ture indicates that every blob that's uploaded to this container uses the default encryption scope.
+	EncryptionScopeOverrideDisabled bool
+
+	// A name-value pair to associate with the container as metadata.
+	MetaData map[string]string
+}
+
+type CreateResponse struct {
+	HttpResponse *http.Response
+}
+
+// Create creates a new container under the specified account.
+// If the container with the same name already exists, the operation fails.
+func (c Client) Create(ctx context.Context, containerName string, input CreateInput) (result CreateResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+	if err = metadata.Validate(input.MetaData); err != nil {
+		err = fmt.Errorf("`input.MetaData` is not valid: %+v", err)
+		return
+	}
+
+	// Retry the container creation if a conflicting container is still in the process of being deleted
+	retryFunc := func(resp *http.Response, _ *odata.OData) (bool, error) {
+		if resp != nil {
+			if response.WasStatusCode(resp, http.StatusConflict) {
+				// TODO: move this error response parsing to a common helper function
+				respBody, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return false, fmt.Errorf("could not parse response body")
+				}
+				resp.Body.Close()
+				respBody = bytes.TrimPrefix(respBody, []byte("\xef\xbb\xbf"))
+				res := ErrorResponse{}
+				if err = xml.Unmarshal(respBody, &res); err != nil {
+					return false, err
+				}
+				resp.Body = io.NopCloser(bytes.NewBuffer(respBody))
+				if res.Code != nil {
+					return strings.Contains(*res.Code, "ContainerBeingDeleted"), nil
+				}
+			}
+		}
+		return false, nil
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: createOptions{
+			input: input,
+		},
+		Path:      fmt.Sprintf("/%s", containerName),
+		RetryFunc: retryFunc,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+var _ client.Options = createOptions{}
+
+type createOptions struct {
+	input CreateInput
+}
+
+func (o createOptions) ToHeaders() *client.Headers {
+	headers := containerOptions{
+		metaData: o.input.MetaData,
+	}.ToHeaders()
+
+	// If this header is not included in the request, container data is private to the account owner.
+	if o.input.AccessLevel != Private {
+		headers.Append("x-ms-blob-public-access", string(o.input.AccessLevel))
+	}
+
+	if o.input.DefaultEncryptionScope != "" {
+		// These two headers must be used together.
+		headers.Append("x-ms-default-encryption-scope", o.input.DefaultEncryptionScope)
+		headers.Append("x-ms-deny-encryption-scope-override", fmt.Sprintf("%t", o.input.EncryptionScopeOverrideDisabled))
+	}
+
+	return headers
+}
+
+func (createOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (createOptions) ToQuery() *client.QueryParams {
+	return containerOptions{}.ToQuery()
+}

--- a/storage/2026-02-06/blob/containers/delete.go
+++ b/storage/2026-02-06/blob/containers/delete.go
@@ -1,0 +1,50 @@
+package containers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+)
+
+type DeleteResponse struct {
+	HttpResponse *http.Response
+}
+
+// Delete marks the specified container for deletion.
+// The container and any blobs contained within it are later deleted during garbage collection.
+func (c Client) Delete(ctx context.Context, containerName string) (result DeleteResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+		},
+		HttpMethod:    http.MethodDelete,
+		OptionsObject: containerOptions{},
+		Path:          fmt.Sprintf("/%s", containerName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}

--- a/storage/2026-02-06/blob/containers/get_properties.go
+++ b/storage/2026-02-06/blob/containers/get_properties.go
@@ -1,0 +1,112 @@
+package containers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type GetPropertiesInput struct {
+	LeaseId string
+}
+
+type GetPropertiesResponse struct {
+	ContainerProperties
+	HttpResponse *http.Response
+}
+
+// GetProperties returns the properties for this Container without a Lease
+func (c Client) GetProperties(ctx context.Context, containerName string, input GetPropertiesInput) (result GetPropertiesResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		OptionsObject: getPropertiesOptions{
+			leaseId: input.LeaseId,
+		},
+		Path: fmt.Sprintf("/%s", containerName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.DefaultEncryptionScope = resp.Header.Get("x-ms-default-encryption-scope")
+				result.LeaseStatus = LeaseStatus(resp.Header.Get("x-ms-lease-status"))
+				result.LeaseState = LeaseState(resp.Header.Get("x-ms-lease-state"))
+				if result.LeaseStatus == Locked {
+					duration := LeaseDuration(resp.Header.Get("x-ms-lease-duration"))
+					result.LeaseDuration = &duration
+				}
+
+				// If this header is not returned in the response, the container is private to the account owner.
+				accessLevel := resp.Header.Get("x-ms-blob-public-access")
+				if accessLevel != "" {
+					result.AccessLevel = AccessLevel(accessLevel)
+				} else {
+					result.AccessLevel = Private
+				}
+
+				// we can't necessarily use strconv.ParseBool here since this could be nil (only in some API versions)
+				result.EncryptionScopeOverrideDisabled = strings.EqualFold(resp.Header.Get("x-ms-deny-encryption-scope-override"), "true")
+				result.HasImmutabilityPolicy = strings.EqualFold(resp.Header.Get("x-ms-has-immutability-policy"), "true")
+				result.HasLegalHold = strings.EqualFold(resp.Header.Get("x-ms-has-legal-hold"), "true")
+
+				result.MetaData = metadata.ParseFromHeaders(resp.Header)
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+var _ client.Options = getPropertiesOptions{}
+
+type getPropertiesOptions struct {
+	leaseId string
+}
+
+func (o getPropertiesOptions) ToHeaders() *client.Headers {
+	headers := containerOptions{}.ToHeaders()
+
+	// If specified, Get Container Properties only succeeds if the container’s lease is active and matches this ID.
+	// If there is no active lease or the ID does not match, 412 (Precondition Failed) is returned.
+	if o.leaseId != "" {
+		headers.Append("x-ms-lease-id", o.leaseId)
+	}
+
+	return headers
+}
+
+func (getPropertiesOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (getPropertiesOptions) ToQuery() *client.QueryParams {
+	return containerOptions{}.ToQuery()
+}

--- a/storage/2026-02-06/blob/containers/lease_acquire.go
+++ b/storage/2026-02-06/blob/containers/lease_acquire.go
@@ -1,0 +1,105 @@
+package containers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type AcquireLeaseInput struct {
+	// Specifies the duration of the lease, in seconds, or negative one (-1) for a lease that never expires.
+	// A non-infinite lease can be between 15 and 60 seconds
+	LeaseDuration int
+
+	ProposedLeaseID string
+}
+
+type AcquireLeaseResponse struct {
+	AcquireLeaseModel
+	HttpResponse *http.Response
+}
+
+type AcquireLeaseModel struct {
+	LeaseID string
+}
+
+// AcquireLease establishes and manages a lock on a container for delete operations.
+func (c Client) AcquireLease(ctx context.Context, containerName string, input AcquireLeaseInput) (result AcquireLeaseResponse, err error) {
+	if containerName == "" {
+		return result, fmt.Errorf("`containerName` cannot be an empty string")
+	}
+	// An infinite lease duration is -1 seconds. A non-infinite lease can be between 15 and 60 seconds
+	if input.LeaseDuration != -1 && (input.LeaseDuration <= 15 || input.LeaseDuration >= 60) {
+		return result, fmt.Errorf("`input.LeaseDuration` must be -1 (infinite), or between 15 and 60 seconds")
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: acquireLeaseOptions{
+			leaseDuration:   input.LeaseDuration,
+			proposedLeaseId: input.ProposedLeaseID,
+		},
+		Path: fmt.Sprintf("/%s", containerName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.LeaseID = resp.Header.Get("x-ms-lease-id")
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+var _ client.Options = acquireLeaseOptions{}
+
+type acquireLeaseOptions struct {
+	leaseDuration   int
+	proposedLeaseId string
+}
+
+func (o acquireLeaseOptions) ToHeaders() *client.Headers {
+	headers := containerOptions{}.ToHeaders()
+
+	headers.Append("x-ms-lease-action", "acquire")
+	headers.Append("x-ms-lease-duration", fmt.Sprintf("%d", o.leaseDuration))
+
+	if o.proposedLeaseId != "" {
+		headers.Append("x-ms-proposed-lease-id", o.proposedLeaseId)
+	}
+
+	return headers
+}
+
+func (o acquireLeaseOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (o acquireLeaseOptions) ToQuery() *client.QueryParams {
+	query := containerOptions{}.ToQuery()
+	query.Append("comp", "lease")
+	return query
+}

--- a/storage/2026-02-06/blob/containers/lease_break.go
+++ b/storage/2026-02-06/blob/containers/lease_break.go
@@ -1,0 +1,116 @@
+package containers
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"net/http"
+	"strconv"
+)
+
+type BreakLeaseInput struct {
+	//  For a break operation, proposed duration the lease should continue
+	//  before it is broken, in seconds, between 0 and 60.
+	//  This break period is only used if it is shorter than the time remaining on the lease.
+	//  If longer, the time remaining on the lease is used.
+	//  A new lease will not be available before the break period has expired,
+	//  but the lease may be held for longer than the break period.
+	//  If this header does not appear with a break operation, a fixed-duration lease breaks
+	//  after the remaining lease period elapses, and an infinite lease breaks immediately.
+	BreakPeriod *int
+
+	LeaseID string
+}
+
+type BreakLeaseResponse struct {
+	BreakLeaseModel
+	HttpResponse *http.Response
+}
+
+type BreakLeaseModel struct {
+	// Approximate time remaining in the lease period, in seconds.
+	// If the break is immediate, 0 is returned.
+	LeaseTime int
+}
+
+// BreakLease breaks a lock based on it's Lease ID
+func (c Client) BreakLease(ctx context.Context, containerName string, input BreakLeaseInput) (result BreakLeaseResponse, err error) {
+	if containerName == "" {
+		return result, fmt.Errorf("`containerName` cannot be an empty string")
+	}
+	if input.LeaseID == "" {
+		return result, fmt.Errorf("`input.LeaseID` cannot be an empty string")
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: breakLeaseOptions{
+			breakPeriod: input.BreakPeriod,
+			leaseId:     input.LeaseID,
+		},
+		Path: fmt.Sprintf("/%s", containerName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				if leaseTimeRaw := resp.Header.Get("x-ms-lease-time"); leaseTimeRaw != "" {
+					if leaseTime, err := strconv.Atoi(leaseTimeRaw); err == nil {
+						result.LeaseTime = leaseTime
+					}
+				}
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+var _ client.Options = breakLeaseOptions{}
+
+type breakLeaseOptions struct {
+	breakPeriod *int
+	leaseId     string
+}
+
+func (o breakLeaseOptions) ToHeaders() *client.Headers {
+	headers := containerOptions{}.ToHeaders()
+
+	headers.Append("x-ms-lease-action", "break")
+	headers.Append("x-ms-lease-id", o.leaseId)
+
+	if o.breakPeriod != nil {
+		headers.Append("x-ms-lease-break-period", fmt.Sprintf("%d", *o.breakPeriod))
+	}
+
+	return headers
+}
+
+func (o breakLeaseOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (o breakLeaseOptions) ToQuery() *client.QueryParams {
+	query := containerOptions{}.ToQuery()
+	query.Append("comp", "lease")
+	return query
+}

--- a/storage/2026-02-06/blob/containers/lease_change.go
+++ b/storage/2026-02-06/blob/containers/lease_change.go
@@ -1,0 +1,104 @@
+package containers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type ChangeLeaseInput struct {
+	ExistingLeaseID string
+	ProposedLeaseID string
+}
+
+type ChangeLeaseResponse struct {
+	ChangeLeaseModel
+	HttpResponse *http.Response
+}
+
+type ChangeLeaseModel struct {
+	LeaseID string
+}
+
+// ChangeLease changes the lock from one Lease ID to another Lease ID
+func (c Client) ChangeLease(ctx context.Context, containerName string, input ChangeLeaseInput) (result ChangeLeaseResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+	if input.ExistingLeaseID == "" {
+		err = fmt.Errorf("`input.ExistingLeaseID` cannot be an empty string")
+		return
+	}
+	if input.ProposedLeaseID == "" {
+		err = fmt.Errorf("`input.ProposedLeaseID` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: changeLeaseOptions{
+			existingLeaseId: input.ExistingLeaseID,
+			proposedLeaseId: input.ProposedLeaseID,
+		},
+		Path: fmt.Sprintf("/%s", containerName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.LeaseID = resp.Header.Get("x-ms-lease-id")
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+var _ client.Options = changeLeaseOptions{}
+
+type changeLeaseOptions struct {
+	existingLeaseId string
+	proposedLeaseId string
+}
+
+func (o changeLeaseOptions) ToHeaders() *client.Headers {
+	headers := containerOptions{}.ToHeaders()
+
+	headers.Append("x-ms-lease-action", "change")
+	headers.Append("x-ms-lease-id", o.existingLeaseId)
+	headers.Append("x-ms-proposed-lease-id", o.proposedLeaseId)
+
+	return headers
+}
+
+func (o changeLeaseOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (o changeLeaseOptions) ToQuery() *client.QueryParams {
+	query := containerOptions{}.ToQuery()
+	query.Append("comp", "lease")
+	return query
+}

--- a/storage/2026-02-06/blob/containers/lease_release.go
+++ b/storage/2026-02-06/blob/containers/lease_release.go
@@ -1,0 +1,85 @@
+package containers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type ReleaseLeaseInput struct {
+	LeaseId string
+}
+
+type ReleaseLeaseResponse struct {
+	HttpResponse *http.Response
+}
+
+// ReleaseLease releases the lock based on the Lease ID
+func (c Client) ReleaseLease(ctx context.Context, containerName string, input ReleaseLeaseInput) (result ReleaseLeaseResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+	if input.LeaseId == "" {
+		err = fmt.Errorf("`input.LeaseId` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: releaseLeaseOptions{
+			leaseId: input.LeaseId,
+		},
+		Path: fmt.Sprintf("/%s", containerName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+var _ client.Options = releaseLeaseOptions{}
+
+type releaseLeaseOptions struct {
+	leaseId string
+}
+
+func (o releaseLeaseOptions) ToHeaders() *client.Headers {
+	headers := containerOptions{}.ToHeaders()
+
+	headers.Append("x-ms-lease-action", "release")
+	headers.Append("x-ms-lease-id", o.leaseId)
+
+	return headers
+}
+
+func (o releaseLeaseOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (o releaseLeaseOptions) ToQuery() *client.QueryParams {
+	query := containerOptions{}.ToQuery()
+	query.Append("comp", "lease")
+	return query
+}

--- a/storage/2026-02-06/blob/containers/lease_renew.go
+++ b/storage/2026-02-06/blob/containers/lease_renew.go
@@ -1,0 +1,85 @@
+package containers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type RenewLeaseInput struct {
+	LeaseId string
+}
+
+type RenewLeaseResponse struct {
+	HttpResponse *http.Response
+}
+
+// RenewLease renews the lock based on the Lease ID
+func (c Client) RenewLease(ctx context.Context, containerName string, input RenewLeaseInput) (result RenewLeaseResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+	if input.LeaseId == "" {
+		err = fmt.Errorf("`input.LeaseId` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: renewLeaseOptions{
+			leaseId: input.LeaseId,
+		},
+		Path: fmt.Sprintf("/%s", containerName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+var _ client.Options = renewLeaseOptions{}
+
+type renewLeaseOptions struct {
+	leaseId string
+}
+
+func (o renewLeaseOptions) ToHeaders() *client.Headers {
+	headers := containerOptions{}.ToHeaders()
+
+	headers.Append("x-ms-lease-action", "renew")
+	headers.Append("x-ms-lease-id", o.leaseId)
+
+	return headers
+}
+
+func (o renewLeaseOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (o renewLeaseOptions) ToQuery() *client.QueryParams {
+	query := containerOptions{}.ToQuery()
+	query.Append("comp", "lease")
+	return query
+}

--- a/storage/2026-02-06/blob/containers/lifecycle_test.go
+++ b/storage/2026-02-06/blob/containers/lifecycle_test.go
@@ -1,0 +1,192 @@
+package containers
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+var _ StorageContainer = Client{}
+
+func TestContainerLifecycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	containerName := fmt.Sprintf("cont-%d", testhelpers.RandomInt())
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindBlobStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+	containersClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.blob.%s", testData.StorageAccountName, *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+	if err := client.PrepareWithSharedKeyAuth(containersClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	// first let's test an empty container
+	input := CreateInput{}
+	_, err = containersClient.Create(ctx, containerName, input)
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error creating: %s", err))
+	}
+
+	container, err := containersClient.GetProperties(ctx, containerName, GetPropertiesInput{})
+	if err != nil {
+		t.Fatalf("retrieving container: %+v", err)
+	}
+
+	if container.AccessLevel != Private {
+		t.Fatalf("Expected Access Level to be Private but got %q", container.AccessLevel)
+	}
+	if len(container.MetaData) != 0 {
+		t.Fatalf("Expected MetaData to be empty but got: %s", container.MetaData)
+	}
+	if container.LeaseStatus != Unlocked {
+		t.Fatalf("Expected Container Lease to be Unlocked but was: %s", container.LeaseStatus)
+	}
+
+	// then update the metadata
+	_, err = containersClient.SetMetaData(ctx, containerName, SetMetaDataInput{
+		MetaData: map[string]string{
+			"dont": "kill-my-vibe",
+		},
+	})
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error updating metadata: %s", err))
+	}
+
+	// give azure time to replicate
+	time.Sleep(2 * time.Second)
+
+	// then assert that
+	container, err = containersClient.GetProperties(ctx, containerName, GetPropertiesInput{})
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error re-retrieving: %s", err))
+	}
+	if len(container.MetaData) != 1 {
+		t.Fatalf("Expected 1 item in the metadata but got: %s", container.MetaData)
+	}
+	if container.MetaData["dont"] != "kill-my-vibe" {
+		t.Fatalf("Expected `kill-my-vibe` but got %q", container.MetaData["dont"])
+	}
+	if container.AccessLevel != Private {
+		t.Fatalf("Expected Access Level to be Private but got %q", container.AccessLevel)
+	}
+	if container.LeaseStatus != Unlocked {
+		t.Fatalf("Expected Container Lease to be Unlocked but was: %s", container.LeaseStatus)
+	}
+
+	// then update the ACL
+	_, err = containersClient.SetAccessControl(ctx, containerName, SetAccessControlInput{
+		AccessLevel: Blob,
+	})
+	if err != nil {
+		t.Fatal(fmt.Errorf("error updating ACL's: %s", err))
+	}
+
+	// give azure some time to replicate
+	time.Sleep(2 * time.Second)
+
+	// then assert that
+	container, err = containersClient.GetProperties(ctx, containerName, GetPropertiesInput{})
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error re-retrieving: %s", err))
+	}
+	if container.AccessLevel != Blob {
+		t.Fatalf("Expected Access Level to be Blob but got %q", container.AccessLevel)
+	}
+	if len(container.MetaData) != 1 {
+		t.Fatalf("Expected 1 item in the metadata but got: %s", container.MetaData)
+	}
+	if container.LeaseStatus != Unlocked {
+		t.Fatalf("Expected Container Lease to be Unlocked but was: %s", container.LeaseStatus)
+	}
+
+	// acquire a lease for 30s
+	acquireLeaseInput := AcquireLeaseInput{
+		LeaseDuration: 30,
+	}
+	acquireLeaseResp, err := containersClient.AcquireLease(ctx, containerName, acquireLeaseInput)
+	if err != nil {
+		t.Fatalf("Error acquiring lease: %s", err)
+	}
+	t.Logf("[DEBUG] Lease ID: %s", acquireLeaseResp.LeaseID)
+
+	// we should then be able to update the ID
+	t.Logf("[DEBUG] Changing lease..")
+	updateLeaseInput := ChangeLeaseInput{
+		ExistingLeaseID: acquireLeaseResp.LeaseID,
+		ProposedLeaseID: "aaaabbbb-aaaa-bbbb-cccc-aaaabbbbcccc",
+	}
+	updateLeaseResp, err := containersClient.ChangeLease(ctx, containerName, updateLeaseInput)
+	if err != nil {
+		t.Fatalf("changing lease: %+v", err)
+	}
+
+	// then renew it
+	_, err = containersClient.RenewLease(ctx, containerName, RenewLeaseInput{
+		LeaseId: updateLeaseResp.LeaseID,
+	})
+	if err != nil {
+		t.Fatalf("Error renewing lease: %s", err)
+	}
+
+	// and then give it a timeout
+	breakPeriod := 20
+	breakLeaseInput := BreakLeaseInput{
+		LeaseID:     updateLeaseResp.LeaseID,
+		BreakPeriod: &breakPeriod,
+	}
+	breakLeaseResp, err := containersClient.BreakLease(ctx, containerName, breakLeaseInput)
+	if err != nil {
+		t.Fatalf("breaking lease: %+v", err)
+	}
+	if breakLeaseResp.LeaseTime == 0 {
+		t.Fatalf("Lease broke immediately when should have waited: %d", breakLeaseResp.LeaseTime)
+	}
+
+	// and finally ditch it
+	_, err = containersClient.ReleaseLease(ctx, containerName, ReleaseLeaseInput{
+		LeaseId: updateLeaseResp.LeaseID,
+	})
+	if err != nil {
+		t.Fatalf("Error releasing lease: %s", err)
+	}
+
+	t.Logf("[DEBUG] Listing blobs in the container..")
+	listInput := ListBlobsInput{}
+	listResult, err := containersClient.ListBlobs(ctx, containerName, listInput)
+	if err != nil {
+		t.Fatalf("listing blobs: %+v", err)
+	}
+
+	if len(listResult.Blobs.Blobs) != 0 {
+		t.Fatalf("Expected there to be no blobs in the container but got %d", len(listResult.Blobs.Blobs))
+	}
+
+	t.Logf("[DEBUG] Deleting..")
+	if _, err = containersClient.Delete(ctx, containerName); err != nil {
+		t.Fatal(fmt.Errorf("Error deleting: %s", err))
+	}
+}

--- a/storage/2026-02-06/blob/containers/list_blobs.go
+++ b/storage/2026-02-06/blob/containers/list_blobs.go
@@ -1,0 +1,179 @@
+package containers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type ListBlobsInput struct {
+	Delimiter  *string
+	Include    *[]Dataset
+	Marker     *string
+	MaxResults *int
+	Prefix     *string
+}
+
+type ListBlobsResponse struct {
+	ListBlobsResult
+
+	HttpResponse *http.Response
+}
+
+type ListBlobsResult struct {
+	Delimiter  string  `xml:"Delimiter"`
+	Marker     string  `xml:"Marker"`
+	MaxResults int     `xml:"MaxResults"`
+	NextMarker *string `xml:"NextMarker,omitempty"`
+	Prefix     string  `xml:"Prefix"`
+	Blobs      Blobs   `xml:"Blobs"`
+}
+
+type Blobs struct {
+	Blobs      []BlobDetails `xml:"Blob"`
+	BlobPrefix *BlobPrefix   `xml:"BlobPrefix"`
+}
+
+type BlobDetails struct {
+	Name       string                 `xml:"Name"`
+	Deleted    bool                   `xml:"Deleted,omitempty"`
+	MetaData   map[string]interface{} `map:"Metadata,omitempty"`
+	Properties *BlobProperties        `xml:"Properties,omitempty"`
+	Snapshot   *string                `xml:"Snapshot,omitempty"`
+}
+
+type BlobProperties struct {
+	AccessTier             *string `xml:"AccessTier,omitempty"`
+	AccessTierInferred     *bool   `xml:"AccessTierInferred,omitempty"`
+	AccessTierChangeTime   *string `xml:"AccessTierChangeTime,omitempty"`
+	BlobType               *string `xml:"BlobType,omitempty"`
+	BlobSequenceNumber     *string `xml:"x-ms-blob-sequence-number,omitempty"`
+	CacheControl           *string `xml:"Cache-Control,omitempty"`
+	ContentEncoding        *string `xml:"ContentEncoding,omitempty"`
+	ContentLanguage        *string `xml:"Content-Language,omitempty"`
+	ContentLength          *int64  `xml:"Content-Length,omitempty"`
+	ContentMD5             *string `xml:"Content-MD5,omitempty"`
+	ContentType            *string `xml:"Content-Type,omitempty"`
+	CopyCompletionTime     *string `xml:"CopyCompletionTime,omitempty"`
+	CopyId                 *string `xml:"CopyId,omitempty"`
+	CopyStatus             *string `xml:"CopyStatus,omitempty"`
+	CopySource             *string `xml:"CopySource,omitempty"`
+	CopyProgress           *string `xml:"CopyProgress,omitempty"`
+	CopyStatusDescription  *string `xml:"CopyStatusDescription,omitempty"`
+	CreationTime           *string `xml:"CreationTime,omitempty"`
+	ETag                   *string `xml:"Etag,omitempty"`
+	DeletedTime            *string `xml:"DeletedTime,omitempty"`
+	IncrementalCopy        *bool   `xml:"IncrementalCopy,omitempty"`
+	LastModified           *string `xml:"Last-Modified,omitempty"`
+	LeaseDuration          *string `xml:"LeaseDuration,omitempty"`
+	LeaseState             *string `xml:"LeaseState,omitempty"`
+	LeaseStatus            *string `xml:"LeaseStatus,omitempty"`
+	RemainingRetentionDays *string `xml:"RemainingRetentionDays,omitempty"`
+	ServerEncrypted        *bool   `xml:"ServerEncrypted,omitempty"`
+}
+
+type BlobPrefix struct {
+	Name string `xml:"Name"`
+}
+
+// ListBlobs lists the blobs matching the specified query within the specified Container
+func (c Client) ListBlobs(ctx context.Context, containerName string, input ListBlobsInput) (result ListBlobsResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+	if input.MaxResults != nil && (*input.MaxResults <= 0 || *input.MaxResults > 5000) {
+		err = fmt.Errorf("`input.MaxResults` can either be nil or between 0 and 5000")
+		return
+	}
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		OptionsObject: listBlobsOptions{
+			delimiter:  input.Delimiter,
+			include:    input.Include,
+			marker:     input.Marker,
+			maxResults: input.MaxResults,
+			prefix:     input.Prefix,
+		},
+		Path: fmt.Sprintf("/%s", containerName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			err = resp.Unmarshal(&result)
+			if err != nil {
+				err = fmt.Errorf("unmarshalling response: %+v", err)
+				return
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+var _ client.Options = listBlobsOptions{}
+
+type listBlobsOptions struct {
+	delimiter  *string
+	include    *[]Dataset
+	marker     *string
+	maxResults *int
+	prefix     *string
+}
+
+func (o listBlobsOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (o listBlobsOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (o listBlobsOptions) ToQuery() *client.QueryParams {
+	query := containerOptions{}.ToQuery()
+	query.Append("comp", "list")
+
+	if o.delimiter != nil {
+		query.Append("delimiter", *o.delimiter)
+	}
+	if o.include != nil {
+		vals := make([]string, 0)
+		for _, v := range *o.include {
+			vals = append(vals, string(v))
+		}
+		include := strings.Join(vals, ",")
+		query.Append("include", include)
+	}
+	if o.marker != nil {
+		query.Append("marker", *o.marker)
+	}
+	if o.maxResults != nil {
+		query.Append("maxresults", fmt.Sprintf("%d", *o.maxResults))
+	}
+	if o.prefix != nil {
+		query.Append("prefix", *o.prefix)
+	}
+	return query
+}

--- a/storage/2026-02-06/blob/containers/models.go
+++ b/storage/2026-02-06/blob/containers/models.go
@@ -1,0 +1,76 @@
+package containers
+
+import "encoding/xml"
+
+type AccessLevel string
+
+var (
+	// Blob specifies public read access for blobs.
+	// Blob data within this container can be read via anonymous request,
+	// but container data is not available.
+	// Clients cannot enumerate blobs within the container via anonymous request.
+	Blob AccessLevel = "blob"
+
+	// Container specifies full public read access for container and blob data.
+	// Clients can enumerate blobs within the container via anonymous request,
+	// but cannot enumerate containers within the storage account.
+	Container AccessLevel = "container"
+
+	// Private specifies that container data is private to the account owner
+	Private AccessLevel = ""
+)
+
+type ContainerProperties struct {
+	AccessLevel                     AccessLevel
+	DefaultEncryptionScope          string
+	EncryptionScopeOverrideDisabled bool
+	LeaseStatus                     LeaseStatus
+	LeaseState                      LeaseState
+	LeaseDuration                   *LeaseDuration
+	MetaData                        map[string]string
+	HasImmutabilityPolicy           bool
+	HasLegalHold                    bool
+}
+
+type Dataset string
+
+var (
+	Copy             Dataset = "copy"
+	Deleted          Dataset = "deleted"
+	MetaData         Dataset = "metadata"
+	Snapshots        Dataset = "snapshots"
+	UncommittedBlobs Dataset = "uncommittedblobs"
+)
+
+type ErrorResponse struct {
+	XMLName xml.Name `xml:"Error"`
+	Code    *string  `xml:"Code"`
+	Message *string  `xml:"Message"`
+}
+
+type LeaseDuration string
+
+var (
+	// If this lease is for a Fixed Duration
+	Fixed LeaseDuration = "fixed"
+
+	// If this lease is for an Indefinite Duration
+	Infinite LeaseDuration = "infinite"
+)
+
+type LeaseState string
+
+var (
+	Available LeaseState = "available"
+	Breaking  LeaseState = "breaking"
+	Broken    LeaseState = "broken"
+	Expired   LeaseState = "expired"
+	Leased    LeaseState = "leased"
+)
+
+type LeaseStatus string
+
+var (
+	Locked   LeaseStatus = "locked"
+	Unlocked LeaseStatus = "unlocked"
+)

--- a/storage/2026-02-06/blob/containers/options.go
+++ b/storage/2026-02-06/blob/containers/options.go
@@ -1,0 +1,35 @@
+package containers
+
+import (
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+var _ client.Options = containerOptions{}
+
+type containerOptions struct {
+	metaData map[string]string
+}
+
+func (o containerOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	metaDataHeaders := make(map[string]interface{})
+	metadata.SetIntoHeaders(metaDataHeaders, o.metaData)
+	for k, v := range metaDataHeaders {
+		headers.Append(k, v.(string))
+	}
+
+	return headers
+}
+
+func (containerOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (containerOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("restype", "container")
+	return out
+}

--- a/storage/2026-02-06/blob/containers/resource_id.go
+++ b/storage/2026-02-06/blob/containers/resource_id.go
@@ -1,0 +1,81 @@
+package containers
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+// GetResourceManagerResourceID returns the Resource Manager specific
+// ResourceID for a specific Storage Container
+func (c Client) GetResourceManagerResourceID(subscriptionID, resourceGroup, accountName, containerName string) string {
+	fmtStr := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/blobServices/default/containers/%s"
+	return fmt.Sprintf(fmtStr, subscriptionID, resourceGroup, accountName, containerName)
+}
+
+// TODO: update this to implement `resourceids.ResourceId` once
+// https://github.com/hashicorp/go-azure-helpers/issues/187 is fixed
+var _ resourceids.Id = ContainerId{}
+
+type ContainerId struct {
+	// AccountId specifies the ID of the Storage Account where this Container exists.
+	AccountId accounts.AccountId
+
+	// ContainerName specifies the name of this Container.
+	ContainerName string
+}
+
+func NewContainerID(accountId accounts.AccountId, containerName string) ContainerId {
+	return ContainerId{
+		AccountId:     accountId,
+		ContainerName: containerName,
+	}
+}
+
+func (b ContainerId) ID() string {
+	return fmt.Sprintf("%s/%s", b.AccountId.ID(), b.ContainerName)
+}
+
+func (b ContainerId) String() string {
+	components := []string{
+		fmt.Sprintf("Account %q", b.AccountId.String()),
+	}
+	return fmt.Sprintf("Container %q (%s)", b.ContainerName, strings.Join(components, " / "))
+}
+
+// ParseContainerID parses `input` into a Container ID using a known `domainSuffix`
+func ParseContainerID(input, domainSuffix string) (*ContainerId, error) {
+	// example: https://foo.blob.core.windows.net/Bar
+	if input == "" {
+		return nil, fmt.Errorf("`input` was empty")
+	}
+
+	account, err := accounts.ParseAccountID(input, domainSuffix)
+	if err != nil {
+		return nil, fmt.Errorf("parsing account %q: %+v", input, err)
+	}
+
+	if account.SubDomainType != accounts.BlobSubDomainType {
+		return nil, fmt.Errorf("expected the subdomain type to be %q but got %q", string(accounts.BlobSubDomainType), string(account.SubDomainType))
+	}
+
+	uri, err := url.Parse(input)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q as a uri: %+v", input, err)
+	}
+
+	path := strings.TrimPrefix(uri.Path, "/")
+	segments := strings.Split(path, "/")
+	if len(segments) != 1 {
+		return nil, fmt.Errorf("expected the path to contain 1 segment but got %d", len(segments))
+	}
+
+	containerName := strings.TrimPrefix(uri.Path, "/")
+	return &ContainerId{
+		AccountId:     *account,
+		ContainerName: containerName,
+	}, nil
+}

--- a/storage/2026-02-06/blob/containers/resource_id_test.go
+++ b/storage/2026-02-06/blob/containers/resource_id_test.go
@@ -1,0 +1,162 @@
+package containers
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+func TestGetResourceManagerResourceID(t *testing.T) {
+	actual := Client{}.GetResourceManagerResourceID("11112222-3333-4444-5555-666677778888", "group1", "account1", "container1")
+	expected := "/subscriptions/11112222-3333-4444-5555-666677778888/resourceGroups/group1/providers/Microsoft.Storage/storageAccounts/account1/blobServices/default/containers/container1"
+	if actual != expected {
+		t.Fatalf("Expected the Resource Manager Resource ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseContainerIDStandard(t *testing.T) {
+	input := "https://example1.blob.core.windows.net/container1"
+	expected := ContainerId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.BlobSubDomainType,
+			DomainSuffix:  "core.windows.net",
+		},
+		ContainerName: "container1",
+	}
+	actual, err := ParseContainerID(input, "core.windows.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if actual.ContainerName != expected.ContainerName {
+		t.Fatalf("expected ContainerName to be %q but got %q", expected.ContainerName, actual.ContainerName)
+	}
+}
+
+func TestParseContainerIDInADNSZone(t *testing.T) {
+	input := "https://example1.zone1.blob.storage.azure.net/container1"
+	expected := ContainerId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.BlobSubDomainType,
+			DomainSuffix:  "storage.azure.net",
+			ZoneName:      pointer.To("zone1"),
+		},
+		ContainerName: "container1",
+	}
+	actual, err := ParseContainerID(input, "storage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if pointer.From(actual.AccountId.ZoneName) != pointer.From(expected.AccountId.ZoneName) {
+		t.Fatalf("expected ZoneName to be %q but got %q", pointer.From(expected.AccountId.ZoneName), pointer.From(actual.AccountId.ZoneName))
+	}
+	if actual.ContainerName != expected.ContainerName {
+		t.Fatalf("expected ContainerName to be %q but got %q", expected.ContainerName, actual.ContainerName)
+	}
+}
+
+func TestParseContainerIDInAnEdgeZone(t *testing.T) {
+	input := "https://example1.blob.zone1.edgestorage.azure.net/container1"
+	expected := ContainerId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.BlobSubDomainType,
+			DomainSuffix:  "edgestorage.azure.net",
+			ZoneName:      pointer.To("zone1"),
+			IsEdgeZone:    true,
+		},
+		ContainerName: "container1",
+	}
+	actual, err := ParseContainerID(input, "edgestorage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if pointer.From(actual.AccountId.ZoneName) != pointer.From(expected.AccountId.ZoneName) {
+		t.Fatalf("expected ZoneName to be %q but got %q", pointer.From(expected.AccountId.ZoneName), pointer.From(actual.AccountId.ZoneName))
+	}
+	if !actual.AccountId.IsEdgeZone {
+		t.Fatalf("expected the Account to be in an Edge Zone but it wasn't")
+	}
+	if actual.ContainerName != expected.ContainerName {
+		t.Fatalf("expected ContainerName to be %q but got %q", expected.ContainerName, actual.ContainerName)
+	}
+}
+
+func TestFormatContainerIDStandard(t *testing.T) {
+	actual := ContainerId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.BlobSubDomainType,
+			DomainSuffix:  "core.windows.net",
+			IsEdgeZone:    false,
+		},
+		ContainerName: "container1",
+	}.ID()
+	expected := "https://example1.blob.core.windows.net/container1"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatContainerIDInDNSZone(t *testing.T) {
+	actual := ContainerId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			ZoneName:      pointer.To("zone2"),
+			SubDomainType: accounts.BlobSubDomainType,
+			DomainSuffix:  "storage.azure.net",
+			IsEdgeZone:    false,
+		},
+		ContainerName: "container1",
+	}.ID()
+	expected := "https://example1.zone2.blob.storage.azure.net/container1"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatContainerIDInEdgeZone(t *testing.T) {
+	actual := ContainerId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			ZoneName:      pointer.To("zone2"),
+			SubDomainType: accounts.BlobSubDomainType,
+			DomainSuffix:  "edgestorage.azure.net",
+			IsEdgeZone:    true,
+		},
+		ContainerName: "container1",
+	}.ID()
+	expected := "https://example1.blob.zone2.edgestorage.azure.net/container1"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}

--- a/storage/2026-02-06/blob/containers/set_acl.go
+++ b/storage/2026-02-06/blob/containers/set_acl.go
@@ -1,0 +1,93 @@
+package containers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type SetAccessControlInput struct {
+	AccessLevel AccessLevel
+	LeaseId     string
+}
+
+type SetAccessControlResponse struct {
+	HttpResponse *http.Response
+}
+
+// SetAccessControl sets the Access Control for a Container without a Lease ID
+// NOTE: The SetAccessControl operation only supports Shared Key authorization.
+func (c Client) SetAccessControl(ctx context.Context, containerName string, input SetAccessControlInput) (result SetAccessControlResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: setAccessControlListOptions{
+			accessLevel: input.AccessLevel,
+			leaseId:     input.LeaseId,
+		},
+		Path: fmt.Sprintf("/%s", containerName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+var _ client.Options = setAccessControlListOptions{}
+
+type setAccessControlListOptions struct {
+	accessLevel AccessLevel
+	leaseId     string
+}
+
+func (o setAccessControlListOptions) ToHeaders() *client.Headers {
+	headers := containerOptions{}.ToHeaders()
+
+	// If this header is not included in the request, container data is private to the account owner.
+	if o.accessLevel != Private {
+		headers.Append("x-ms-blob-public-access", string(o.accessLevel))
+	}
+
+	// If specified, Get Container Properties only succeeds if the container’s lease is active and matches this ID.
+	// If there is no active lease or the ID does not match, 412 (Precondition Failed) is returned.
+	if o.leaseId != "" {
+		headers.Append("x-ms-lease-id", o.leaseId)
+	}
+
+	return headers
+}
+
+func (o setAccessControlListOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (o setAccessControlListOptions) ToQuery() *client.QueryParams {
+	query := containerOptions{}.ToQuery()
+	query.Append("comp", "acl")
+	return query
+}

--- a/storage/2026-02-06/blob/containers/set_metadata.go
+++ b/storage/2026-02-06/blob/containers/set_metadata.go
@@ -1,0 +1,94 @@
+package containers
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type SetMetaDataInput struct {
+	MetaData map[string]string
+	LeaseId  string
+}
+
+type SetMetaDataResponse struct {
+	HttpResponse *http.Response
+}
+
+// SetMetaData sets the specified MetaData on the Container without a Lease ID
+func (c Client) SetMetaData(ctx context.Context, containerName string, input SetMetaDataInput) (result SetMetaDataResponse, err error) {
+	if containerName == "" {
+		err = fmt.Errorf("`containerName` cannot be an empty string")
+		return
+	}
+	if err = metadata.Validate(input.MetaData); err != nil {
+		err = fmt.Errorf("`input.MetaData` is not valid: %s", err)
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: setMetaDataOptions{
+			metaData: input.MetaData,
+			leaseId:  input.LeaseId,
+		},
+		Path: fmt.Sprintf("/%s", containerName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+var _ client.Options = setMetaDataOptions{}
+
+type setMetaDataOptions struct {
+	metaData map[string]string
+	leaseId  string
+}
+
+func (o setMetaDataOptions) ToHeaders() *client.Headers {
+	headers := containerOptions{
+		metaData: o.metaData,
+	}.ToHeaders()
+
+	// If specified, Get Container Properties only succeeds if the container’s lease is active and matches this ID.
+	// If there is no active lease or the ID does not match, 412 (Precondition Failed) is returned.
+	if o.leaseId != "" {
+		headers.Append("x-ms-lease-id", o.leaseId)
+	}
+
+	return headers
+}
+
+func (o setMetaDataOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (o setMetaDataOptions) ToQuery() *client.QueryParams {
+	query := containerOptions{}.ToQuery()
+	query.Append("comp", "metadata")
+	return query
+}

--- a/storage/2026-02-06/blob/containers/version.go
+++ b/storage/2026-02-06/blob/containers/version.go
@@ -1,0 +1,4 @@
+package containers
+
+const apiVersion = "2026-02-06"
+const componentName = "blob/containers"

--- a/storage/2026-02-06/datalakestore/filesystems/README.md
+++ b/storage/2026-02-06/datalakestore/filesystems/README.md
@@ -1,0 +1,53 @@
+## Data Lake Storage Gen2 File Systems SDK for API version 2026-02-06
+
+This package allows you to interact with the Data Lake Storage Gen2 File Systems API
+
+### Supported Authorizers
+
+* Azure Active Directory (for the Resource Endpoint `https://storage.azure.com`)
+
+### Example Usage
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	
+    "github.com/hashicorp/go-azure-helpers/authentication"
+    "github.com/hashicorp/go-azure-helpers/sender"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+    "github.com/jackofallops/giovanni/storage/2026-02-06/datalakestore/filesystems"
+)
+
+func Example() error {
+	accountName := "storageaccount1"
+    fileSystemName := "filesystem1"
+	storageAccountKey := "ABC123...."
+	domainSuffix := "core.windows.net"
+	
+
+	auth, err := auth.NewSharedKeyAuthorizer(accountName, storageAccountKey, auth.SharedKey)
+	if err != nil {
+		return fmt.Errorf("building SharedKey authorizer: %+v", err)
+	}
+	
+    fileSystemsClient, err := filesystems.NewWithBaseUri(fmt.Sprintf("https://%s.dfs.%s", accountName, domainSuffix))
+	if err != nil {
+		return fmt.Errorf("building client for environment: %+v", err)
+	}
+	fileSystemsClient.Client.SetAuthorizer(auth)
+
+	input := filesystems.CreateInput{
+		Properties: map[string]string{},
+	}
+
+	ctx := context.Background()
+	if _, err = fileSystemsClient.Create(ctx, fileSystemName, input); err != nil {
+		return fmt.Errorf("Error creating: %s", err)
+	}
+	
+    return nil 
+}
+```

--- a/storage/2026-02-06/datalakestore/filesystems/client.go
+++ b/storage/2026-02-06/datalakestore/filesystems/client.go
@@ -1,0 +1,23 @@
+package filesystems
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/dataplane/storage"
+)
+
+// Client is the base client for Data Lake Store Filesystems.
+type Client struct {
+	Client *storage.Client
+}
+
+func NewWithBaseUri(baseUri string) (*Client, error) {
+	baseClient, err := storage.NewStorageClient(baseUri, componentName, apiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("building base client: %+v", err)
+	}
+
+	return &Client{
+		Client: baseClient,
+	}, nil
+}

--- a/storage/2026-02-06/datalakestore/filesystems/create.go
+++ b/storage/2026-02-06/datalakestore/filesystems/create.go
@@ -1,0 +1,91 @@
+package filesystems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type CreateInput struct {
+	// The encryption scope to set as the default on the filesystem.
+	DefaultEncryptionScope string
+
+	// A map of base64-encoded strings to store as user-defined properties with the File System
+	// Note that items may only contain ASCII characters in the ISO-8859-1 character set.
+	// This automatically gets converted to a comma-separated list of name and
+	// value pairs before sending to the API
+	Properties map[string]string
+}
+
+type CreateResponse struct {
+	HttpResponse *http.Response
+}
+
+// Create creates a Data Lake Store Gen2 FileSystem within a Storage Account
+func (c Client) Create(ctx context.Context, fileSystemName string, input CreateInput) (result CreateResponse, err error) {
+	if fileSystemName == "" {
+		err = fmt.Errorf("`fileSystemName` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: createOptions{
+			input: input,
+		},
+
+		Path: fmt.Sprintf("/%s", fileSystemName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type createOptions struct {
+	input CreateInput
+}
+
+func (o createOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	if o.input.DefaultEncryptionScope != "" {
+		headers.Append("x-ms-default-encryption-scope", o.input.DefaultEncryptionScope)
+	}
+
+	props := buildProperties(o.input.Properties)
+	if props != "" {
+		headers.Append("x-ms-properties", props)
+	}
+
+	return headers
+}
+
+func (createOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (createOptions) ToQuery() *client.QueryParams {
+	return fileSystemOptions{}.ToQuery()
+}

--- a/storage/2026-02-06/datalakestore/filesystems/create_test.go
+++ b/storage/2026-02-06/datalakestore/filesystems/create_test.go
@@ -1,0 +1,69 @@
+package filesystems
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+func TestCreateHasNoTagsByDefault(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	fileSystemName := fmt.Sprintf("acctestfs-%s", testhelpers.RandomString())
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindBlobStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+
+	fileSystemsClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.%s.%s", accountName, "dfs", *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err := client.PrepareWithSharedKeyAuth(fileSystemsClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	t.Logf("[DEBUG] Creating an empty File System..")
+	input := CreateInput{
+		Properties: map[string]string{},
+	}
+	if _, err = fileSystemsClient.Create(ctx, fileSystemName, input); err != nil {
+		t.Fatal(fmt.Errorf("Error creating: %s", err))
+	}
+
+	t.Logf("[DEBUG] Retrieving the Properties..")
+	props, err := fileSystemsClient.GetProperties(ctx, fileSystemName)
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error getting properties: %s", err))
+	}
+
+	if len(props.Properties) != 0 {
+		t.Fatalf("Expected 0 properties by default but got %d", len(props.Properties))
+	}
+
+	t.Logf("[DEBUG] Deleting File System..")
+	if _, err := fileSystemsClient.Delete(ctx, fileSystemName); err != nil {
+		t.Fatalf("Error deleting: %s", err)
+	}
+}

--- a/storage/2026-02-06/datalakestore/filesystems/delete.go
+++ b/storage/2026-02-06/datalakestore/filesystems/delete.go
@@ -1,0 +1,49 @@
+package filesystems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+)
+
+type DeleteResponse struct {
+	HttpResponse *http.Response
+}
+
+// Delete deletes a Data Lake Store Gen2 FileSystem within a Storage Account
+func (c Client) Delete(ctx context.Context, fileSystemName string) (result DeleteResponse, err error) {
+	if fileSystemName == "" {
+		err = fmt.Errorf("`fileSystemName` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+		},
+		HttpMethod:    http.MethodDelete,
+		OptionsObject: fileSystemOptions{},
+		Path:          fmt.Sprintf("/%s", fileSystemName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}

--- a/storage/2026-02-06/datalakestore/filesystems/helpers.go
+++ b/storage/2026-02-06/datalakestore/filesystems/helpers.go
@@ -1,0 +1,40 @@
+package filesystems
+
+import (
+	"fmt"
+	"strings"
+)
+
+func buildProperties(input map[string]string) string {
+	// properties has to be a comma-separated key-value pair
+	properties := make([]string, 0)
+
+	for k, v := range input {
+		properties = append(properties, fmt.Sprintf("%s=%s", k, v))
+	}
+
+	return strings.Join(properties, ",")
+}
+
+func parseProperties(input string) (*map[string]string, error) {
+	properties := make(map[string]string)
+	if input == "" {
+		return &properties, nil
+	}
+
+	// properties is a comma-separated list of key-value pairs
+	splitProperties := strings.Split(input, ",")
+	for _, propertyRaw := range splitProperties {
+		// because these are base64-encoded they're likely to end in at least one =
+		// as such we can't string split on that -_-
+		position := strings.Index(propertyRaw, "=")
+		if position < 0 {
+			return nil, fmt.Errorf("expected an equal sign in the key value pair: %q", propertyRaw)
+		}
+
+		key := propertyRaw[0:position]
+		value := propertyRaw[position+1:]
+		properties[key] = value
+	}
+	return &properties, nil
+}

--- a/storage/2026-02-06/datalakestore/filesystems/helpers_test.go
+++ b/storage/2026-02-06/datalakestore/filesystems/helpers_test.go
@@ -1,0 +1,76 @@
+package filesystems
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseProperties(t *testing.T) {
+	testData := []struct {
+		name        string
+		input       string
+		expected    map[string]string
+		expectError bool
+	}{
+		{
+			name:        "no items",
+			input:       "",
+			expected:    map[string]string{},
+			expectError: false,
+		},
+		{
+			name:        "invalid item",
+			input:       "hello",
+			expectError: true,
+		},
+		{
+			name:  "single item",
+			input: "hello=world",
+			expected: map[string]string{
+				"hello": "world",
+			},
+		},
+		{
+			name:  "single-item-base64",
+			input: "hello=aGVsbG8=",
+			expected: map[string]string{
+				"hello": "aGVsbG8=",
+			},
+			expectError: false,
+		},
+		{
+			name:  "single-item-base64-multipleequals",
+			input: "hello=d29uZGVybGFuZA==",
+			expected: map[string]string{
+				"hello": "d29uZGVybGFuZA==",
+			},
+			expectError: false,
+		},
+		{
+			name:  "multiple-items-base64",
+			input: "hello=d29uZGVybGFuZA==,private=ZXll",
+
+			expected: map[string]string{
+				"hello":   "d29uZGVybGFuZA==",
+				"private": "ZXll",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, testCase := range testData {
+		t.Logf("[DEBUG] Test %q", testCase.name)
+
+		actual, err := parseProperties(testCase.input)
+		if err != nil {
+			if testCase.expectError {
+				continue
+			}
+
+			t.Fatalf("[DEBUG] Didn't expect an error but got %s", err)
+		}
+		if !reflect.DeepEqual(testCase.expected, *actual) {
+			t.Fatalf("Expected %+v but got %+v", testCase.expected, *actual)
+		}
+	}
+}

--- a/storage/2026-02-06/datalakestore/filesystems/lifecycle_test.go
+++ b/storage/2026-02-06/datalakestore/filesystems/lifecycle_test.go
@@ -1,0 +1,99 @@
+package filesystems
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+func TestLifecycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	fileSystemName := fmt.Sprintf("acctestfs-%s", testhelpers.RandomString())
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindBlobStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+	fileSystemsClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.%s.%s", accountName, "dfs", *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err := client.PrepareWithSharedKeyAuth(fileSystemsClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	t.Logf("[DEBUG] Creating an empty File System..")
+	input := CreateInput{
+		Properties: map[string]string{
+			"hello": "aGVsbG8=",
+		},
+	}
+	if _, err = fileSystemsClient.Create(ctx, fileSystemName, input); err != nil {
+		t.Fatal(fmt.Errorf("Error creating: %s", err))
+	}
+
+	t.Logf("[DEBUG] Retrieving the Properties..")
+	props, err := fileSystemsClient.GetProperties(ctx, fileSystemName)
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error getting properties: %s", err))
+	}
+
+	if len(props.Properties) != 1 {
+		t.Fatalf("Expected 1 properties by default but got %d", len(props.Properties))
+	}
+	if props.Properties["hello"] != "aGVsbG8=" {
+		t.Fatalf("Expected `hello` to be `aGVsbG8=` but got %q", props.Properties["hello"])
+	}
+
+	t.Logf("[DEBUG] Updating the properties..")
+	setInput := SetPropertiesInput{
+		Properties: map[string]string{
+			"hello":   "d29uZGVybGFuZA==",
+			"private": "ZXll",
+		},
+	}
+	if _, err := fileSystemsClient.SetProperties(ctx, fileSystemName, setInput); err != nil {
+		t.Fatalf("Error setting properties: %s", err)
+	}
+
+	t.Logf("[DEBUG] Re-Retrieving the Properties..")
+	props, err = fileSystemsClient.GetProperties(ctx, fileSystemName)
+	if err != nil {
+		t.Fatal(fmt.Errorf("Error getting properties: %s", err))
+	}
+	if len(props.Properties) != 2 {
+		t.Fatalf("Expected 2 properties by default but got %d", len(props.Properties))
+	}
+	if props.Properties["hello"] != "d29uZGVybGFuZA==" {
+		t.Fatalf("Expected `hello` to be `d29uZGVybGFuZA==` but got %q", props.Properties["hello"])
+	}
+	if props.Properties["private"] != "ZXll" {
+		t.Fatalf("Expected `private` to be `ZXll` but got %q", props.Properties["private"])
+	}
+
+	t.Logf("[DEBUG] Deleting File System..")
+	if _, err := fileSystemsClient.Delete(ctx, fileSystemName); err != nil {
+		t.Fatalf("Error deleting: %s", err)
+	}
+}

--- a/storage/2026-02-06/datalakestore/filesystems/options.go
+++ b/storage/2026-02-06/datalakestore/filesystems/options.go
@@ -1,0 +1,32 @@
+package filesystems
+
+import (
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+var _ client.Options = fileSystemOptions{}
+
+type fileSystemOptions struct {
+	properties map[string]string
+}
+
+func (o fileSystemOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	props := buildProperties(o.properties)
+	if props != "" {
+		headers.Append("x-ms-properties", props)
+	}
+
+	return headers
+}
+
+func (fileSystemOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (fileSystemOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("resource", "filesystem")
+	return out
+}

--- a/storage/2026-02-06/datalakestore/filesystems/properties_get.go
+++ b/storage/2026-02-06/datalakestore/filesystems/properties_get.go
@@ -1,0 +1,78 @@
+package filesystems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+)
+
+type GetPropertiesResponse struct {
+	HttpResponse *http.Response
+
+	// The default encryption scope for the filesystem.
+	DefaultEncryptionScope string
+
+	// A map of base64-encoded strings to store as user-defined properties with the File System
+	// Note that items may only contain ASCII characters in the ISO-8859-1 character set.
+	// This automatically gets converted to a comma-separated list of name and
+	// value pairs before sending to the API
+	Properties map[string]string
+
+	// Is Hierarchical Namespace Enabled?
+	NamespaceEnabled bool
+}
+
+// GetProperties gets the properties for a Data Lake Store Gen2 FileSystem within a Storage Account
+func (c Client) GetProperties(ctx context.Context, fileSystemName string) (result GetPropertiesResponse, err error) {
+	if fileSystemName == "" {
+		err = fmt.Errorf("`fileSystemName` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodHead,
+		OptionsObject: fileSystemOptions{},
+		Path:          fmt.Sprintf("/%s", fileSystemName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.DefaultEncryptionScope = resp.Header.Get("x-ms-default-encryption-scope")
+
+				propertiesRaw := resp.Header.Get("x-ms-properties")
+				var properties *map[string]string
+				properties, err = parseProperties(propertiesRaw)
+				if err != nil {
+					return
+				}
+
+				result.Properties = *properties
+				result.NamespaceEnabled = strings.EqualFold(resp.Header.Get("x-ms-namespace-enabled"), "true")
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}

--- a/storage/2026-02-06/datalakestore/filesystems/properties_set.go
+++ b/storage/2026-02-06/datalakestore/filesystems/properties_set.go
@@ -1,0 +1,103 @@
+package filesystems
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type SetPropertiesInput struct {
+	// A map of base64-encoded strings to store as user-defined properties with the File System
+	// Note that items may only contain ASCII characters in the ISO-8859-1 character set.
+	// This automatically gets converted to a comma-separated list of name and
+	// value pairs before sending to the API
+	Properties map[string]string
+
+	// Optional - A date and time value.
+	// Specify this header to perform the operation only if the resource has been modified since the specified date and time.
+	IfModifiedSince *string
+
+	// Optional - A date and time value.
+	// Specify this header to perform the operation only if the resource has not been modified since the specified date and time.
+	IfUnmodifiedSince *string
+}
+
+type SetPropertiesResponse struct {
+	HttpResponse *http.Response
+}
+
+// SetProperties sets the Properties for a Data Lake Store Gen2 FileSystem within a Storage Account
+func (c Client) SetProperties(ctx context.Context, fileSystemName string, input SetPropertiesInput) (result SetPropertiesResponse, err error) {
+	if fileSystemName == "" {
+		err = fmt.Errorf("`fileSystemName` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		OptionsObject: setPropertiesOptions{
+			properties:        input.Properties,
+			ifUnmodifiedSince: input.IfUnmodifiedSince,
+			ifModifiedSince:   input.IfModifiedSince,
+		},
+
+		Path: fmt.Sprintf("/%s", fileSystemName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type setPropertiesOptions struct {
+	properties        map[string]string
+	ifModifiedSince   *string
+	ifUnmodifiedSince *string
+}
+
+func (o setPropertiesOptions) ToHeaders() *client.Headers {
+
+	headers := &client.Headers{}
+	props := buildProperties(o.properties)
+	if props != "" {
+		headers.Append("x-ms-properties", props)
+	}
+
+	if o.ifModifiedSince != nil {
+		headers.Append("If-Modified-Since", *o.ifModifiedSince)
+	}
+	if o.ifUnmodifiedSince != nil {
+		headers.Append("If-Unmodified-Since", *o.ifUnmodifiedSince)
+	}
+
+	return headers
+}
+
+func (setPropertiesOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (setPropertiesOptions) ToQuery() *client.QueryParams {
+	return fileSystemOptions{}.ToQuery()
+}

--- a/storage/2026-02-06/datalakestore/filesystems/resource_id.go
+++ b/storage/2026-02-06/datalakestore/filesystems/resource_id.go
@@ -1,0 +1,81 @@
+package filesystems
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+// GetResourceManagerResourceID returns the Resource Manager specific
+// ResourceID for a specific Data Lake FileSystem
+func (c Client) GetResourceManagerResourceID(subscriptionID, resourceGroup, accountName, fileSystemName string) string {
+	fmtStr := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/blobServices/default/containers/%s"
+	return fmt.Sprintf(fmtStr, subscriptionID, resourceGroup, accountName, fileSystemName)
+}
+
+// TODO: update this to implement `resourceids.ResourceId` once
+// https://github.com/hashicorp/go-azure-helpers/issues/187 is fixed
+var _ resourceids.Id = FileSystemId{}
+
+type FileSystemId struct {
+	// AccountId specifies the ID of the Storage Account where this Data Lake FileSystem exists.
+	AccountId accounts.AccountId
+
+	// FileSystemName specifies the name of this Data Lake FileSystem.
+	FileSystemName string
+}
+
+func NewFileSystemID(accountId accounts.AccountId, fileSystemName string) FileSystemId {
+	return FileSystemId{
+		AccountId:      accountId,
+		FileSystemName: fileSystemName,
+	}
+}
+
+func (b FileSystemId) ID() string {
+	return fmt.Sprintf("%s/%s", b.AccountId.ID(), b.FileSystemName)
+}
+
+func (b FileSystemId) String() string {
+	components := []string{
+		fmt.Sprintf("Account %q", b.AccountId.String()),
+	}
+	return fmt.Sprintf("File System %q (%s)", b.FileSystemName, strings.Join(components, " / "))
+}
+
+// ParseFileSystemID parses `input` into a File System ID using a known `domainSuffix`
+func ParseFileSystemID(input, domainSuffix string) (*FileSystemId, error) {
+	// example: https://foo.dfs.core.windows.net/Bar
+	if input == "" {
+		return nil, fmt.Errorf("`input` was empty")
+	}
+
+	account, err := accounts.ParseAccountID(input, domainSuffix)
+	if err != nil {
+		return nil, fmt.Errorf("parsing account %q: %+v", input, err)
+	}
+
+	if account.SubDomainType != accounts.DataLakeStoreSubDomainType {
+		return nil, fmt.Errorf("expected the subdomain type to be %q but got %q", string(accounts.DataLakeStoreSubDomainType), string(account.SubDomainType))
+	}
+
+	uri, err := url.Parse(input)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q as a uri: %+v", input, err)
+	}
+
+	path := strings.TrimPrefix(uri.Path, "/")
+	segments := strings.Split(path, "/")
+	if len(segments) != 1 {
+		return nil, fmt.Errorf("expected the path to contain 1 segment but got %d", len(segments))
+	}
+
+	fileSystemName := segments[0]
+	return &FileSystemId{
+		AccountId:      *account,
+		FileSystemName: fileSystemName,
+	}, nil
+}

--- a/storage/2026-02-06/datalakestore/filesystems/resource_id_test.go
+++ b/storage/2026-02-06/datalakestore/filesystems/resource_id_test.go
@@ -1,0 +1,162 @@
+package filesystems
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+func TestGetResourceManagerResourceID(t *testing.T) {
+	actual := Client{}.GetResourceManagerResourceID("11112222-3333-4444-5555-666677778888", "group1", "account1", "container1")
+	expected := "/subscriptions/11112222-3333-4444-5555-666677778888/resourceGroups/group1/providers/Microsoft.Storage/storageAccounts/account1/blobServices/default/containers/container1"
+	if actual != expected {
+		t.Fatalf("Expected the Resource Manager Resource ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseFileSystemIDStandard(t *testing.T) {
+	input := "https://example1.dfs.core.windows.net/fileSystem1"
+	expected := FileSystemId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.DataLakeStoreSubDomainType,
+			DomainSuffix:  "core.windows.net",
+		},
+		FileSystemName: "fileSystem1",
+	}
+	actual, err := ParseFileSystemID(input, "core.windows.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if actual.FileSystemName != expected.FileSystemName {
+		t.Fatalf("expected FileSystemName to be %q but got %q", expected.FileSystemName, actual.FileSystemName)
+	}
+}
+
+func TestParseFileSystemIDInADNSZone(t *testing.T) {
+	input := "https://example1.zone1.dfs.storage.azure.net/fileSystem1"
+	expected := FileSystemId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.DataLakeStoreSubDomainType,
+			DomainSuffix:  "storage.azure.net",
+			ZoneName:      pointer.To("zone1"),
+		},
+		FileSystemName: "fileSystem1",
+	}
+	actual, err := ParseFileSystemID(input, "storage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if pointer.From(actual.AccountId.ZoneName) != pointer.From(expected.AccountId.ZoneName) {
+		t.Fatalf("expected ZoneName to be %q but got %q", pointer.From(expected.AccountId.ZoneName), pointer.From(actual.AccountId.ZoneName))
+	}
+	if actual.FileSystemName != expected.FileSystemName {
+		t.Fatalf("expected FileSystemName to be %q but got %q", expected.FileSystemName, actual.FileSystemName)
+	}
+}
+
+func TestParseFileSystemIDInAnEdgeZone(t *testing.T) {
+	input := "https://example1.dfs.zone1.edgestorage.azure.net/fileSystem1"
+	expected := FileSystemId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.DataLakeStoreSubDomainType,
+			DomainSuffix:  "edgestorage.azure.net",
+			ZoneName:      pointer.To("zone1"),
+			IsEdgeZone:    true,
+		},
+		FileSystemName: "fileSystem1",
+	}
+	actual, err := ParseFileSystemID(input, "edgestorage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if pointer.From(actual.AccountId.ZoneName) != pointer.From(expected.AccountId.ZoneName) {
+		t.Fatalf("expected ZoneName to be %q but got %q", pointer.From(expected.AccountId.ZoneName), pointer.From(actual.AccountId.ZoneName))
+	}
+	if !actual.AccountId.IsEdgeZone {
+		t.Fatalf("expected the Account to be in an Edge Zone but it wasn't")
+	}
+	if actual.FileSystemName != expected.FileSystemName {
+		t.Fatalf("expected FileSystemName to be %q but got %q", expected.FileSystemName, actual.FileSystemName)
+	}
+}
+
+func TestFormatFileSystemIDStandard(t *testing.T) {
+	actual := FileSystemId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.DataLakeStoreSubDomainType,
+			DomainSuffix:  "core.windows.net",
+			IsEdgeZone:    false,
+		},
+		FileSystemName: "fileSystem1",
+	}.ID()
+	expected := "https://example1.dfs.core.windows.net/fileSystem1"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatFileSystemIDInDNSZone(t *testing.T) {
+	actual := FileSystemId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			ZoneName:      pointer.To("zone2"),
+			SubDomainType: accounts.DataLakeStoreSubDomainType,
+			DomainSuffix:  "storage.azure.net",
+			IsEdgeZone:    false,
+		},
+		FileSystemName: "fileSystem1",
+	}.ID()
+	expected := "https://example1.zone2.dfs.storage.azure.net/fileSystem1"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatFileSystemIDInEdgeZone(t *testing.T) {
+	actual := FileSystemId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			ZoneName:      pointer.To("zone2"),
+			SubDomainType: accounts.DataLakeStoreSubDomainType,
+			DomainSuffix:  "edgestorage.azure.net",
+			IsEdgeZone:    true,
+		},
+		FileSystemName: "fileSystem1",
+	}.ID()
+	expected := "https://example1.dfs.zone2.edgestorage.azure.net/fileSystem1"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}

--- a/storage/2026-02-06/datalakestore/filesystems/version.go
+++ b/storage/2026-02-06/datalakestore/filesystems/version.go
@@ -1,0 +1,4 @@
+package filesystems
+
+const apiVersion = "2026-02-06"
+const componentName = "datalakestore/filesystems"

--- a/storage/2026-02-06/datalakestore/paths/client.go
+++ b/storage/2026-02-06/datalakestore/paths/client.go
@@ -1,0 +1,22 @@
+package paths
+
+import (
+	"fmt"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/dataplane/storage"
+)
+
+// Client is the base client for Data Lake Storage Path
+type Client struct {
+	Client *storage.Client
+}
+
+func NewWithBaseUri(baseUri string) (*Client, error) {
+	baseClient, err := storage.NewStorageClient(baseUri, componentName, apiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("building base client: %+v", err)
+	}
+
+	return &Client{
+		Client: baseClient,
+	}, nil
+}

--- a/storage/2026-02-06/datalakestore/paths/create.go
+++ b/storage/2026-02-06/datalakestore/paths/create.go
@@ -1,0 +1,76 @@
+package paths
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type PathResource string
+
+const PathResourceFile PathResource = "file"
+const PathResourceDirectory PathResource = "directory"
+
+type CreateInput struct {
+	Resource PathResource
+}
+
+type CreateResponse struct {
+	HttpResponse *http.Response
+}
+
+// Create creates a Data Lake Store Gen2 Path within a Storage Account
+func (c Client) Create(ctx context.Context, fileSystemName string, path string, input CreateInput) (result CreateResponse, err error) {
+
+	if fileSystemName == "" {
+		return result, fmt.Errorf("`fileSystemName` cannot be an empty string")
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: CreateInput{
+			Resource: input.Resource,
+		},
+
+		Path: fmt.Sprintf("/%s/%s", fileSystemName, path),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return result, err
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return result, err
+	}
+
+	return
+}
+
+func (c CreateInput) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (c CreateInput) ToOData() *odata.Query {
+	return nil
+}
+
+func (c CreateInput) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("resource", string(c.Resource))
+	return out
+}

--- a/storage/2026-02-06/datalakestore/paths/create_test.go
+++ b/storage/2026-02-06/datalakestore/paths/create_test.go
@@ -1,0 +1,82 @@
+package paths
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2020-08-04/datalakestore/filesystems"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+func TestCreateDirectory(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	fileSystemName := fmt.Sprintf("acctestfs-%s", testhelpers.RandomString())
+	path := "test"
+
+	testData, err := client.BuildTestResourcesWithHns(ctx, resourceGroup, accountName, storageaccounts.KindBlobStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+
+	baseUri := fmt.Sprintf("https://%s.%s.%s", accountName, "dfs", *domainSuffix)
+
+	fileSystemsClient, err := filesystems.NewWithBaseUri(baseUri)
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err := client.PrepareWithSharedKeyAuth(fileSystemsClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	t.Logf("[DEBUG] Creating an empty File System..")
+	fileSystemInput := filesystems.CreateInput{
+		Properties: map[string]string{},
+	}
+	if _, err = fileSystemsClient.Create(ctx, fileSystemName, fileSystemInput); err != nil {
+		t.Fatal(fmt.Errorf("error creating: %s", err))
+	}
+
+	t.Logf("[DEBUG] Creating path..")
+
+	pathsClient, err := NewWithBaseUri(baseUri)
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err := client.PrepareWithSharedKeyAuth(pathsClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	input := CreateInput{
+		Resource: PathResourceDirectory,
+	}
+
+	if _, err = pathsClient.Create(ctx, fileSystemName, path, input); err != nil {
+		t.Fatal(fmt.Errorf("error creating path: %s", err))
+	}
+
+	t.Logf("[DEBUG] Deleting File System..")
+	if _, err := fileSystemsClient.Delete(ctx, fileSystemName); err != nil {
+		t.Fatalf("Error deleting: %s", err)
+	}
+}

--- a/storage/2026-02-06/datalakestore/paths/create_test.go
+++ b/storage/2026-02-06/datalakestore/paths/create_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
-	"github.com/jackofallops/giovanni/storage/2020-08-04/datalakestore/filesystems"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/datalakestore/filesystems"
 	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
 )
 

--- a/storage/2026-02-06/datalakestore/paths/delete.go
+++ b/storage/2026-02-06/datalakestore/paths/delete.go
@@ -1,0 +1,48 @@
+package paths
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+)
+
+type DeleteResponse struct {
+	HttpResponse *http.Response
+}
+
+// Delete deletes a Data Lake Store Gen2 FileSystem within a Storage Account
+func (c Client) Delete(ctx context.Context, fileSystemName string, path string) (result DeleteResponse, err error) {
+
+	if fileSystemName == "" {
+		return result, fmt.Errorf("`fileSystemName` cannot be an empty string")
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodDelete,
+		OptionsObject: nil,
+		Path:          fmt.Sprintf("/%s/%s", fileSystemName, path),
+	}
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}

--- a/storage/2026-02-06/datalakestore/paths/lifecycle_test.go
+++ b/storage/2026-02-06/datalakestore/paths/lifecycle_test.go
@@ -1,0 +1,120 @@
+package paths
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2020-08-04/datalakestore/filesystems"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+func TestLifecycle(t *testing.T) {
+	const defaultACLString = "user::rwx,group::r-x,other::---"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	fileSystemName := fmt.Sprintf("acctestfs-%s", testhelpers.RandomString())
+	path := "test"
+
+	testData, err := client.BuildTestResourcesWithHns(ctx, resourceGroup, accountName, storageaccounts.KindBlobStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+
+	baseUri := fmt.Sprintf("https://%s.%s.%s", accountName, "dfs", *domainSuffix)
+
+	fileSystemsClient, err := filesystems.NewWithBaseUri(baseUri)
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+	if err := client.PrepareWithSharedKeyAuth(fileSystemsClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	pathsClient, err := NewWithBaseUri(baseUri)
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+	if err := client.PrepareWithSharedKeyAuth(pathsClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	t.Logf("[DEBUG] Creating an empty File System..")
+	fileSystemInput := filesystems.CreateInput{}
+	if _, err = fileSystemsClient.Create(ctx, fileSystemName, fileSystemInput); err != nil {
+		t.Fatal(fmt.Errorf("error creating: %s", err))
+	}
+
+	t.Logf("[DEBUG] Creating folder 'test' ..")
+	input := CreateInput{
+		Resource: PathResourceDirectory,
+	}
+	if _, err = pathsClient.Create(ctx, fileSystemName, path, input); err != nil {
+		t.Fatal(fmt.Errorf("error creating: %s", err))
+	}
+
+	t.Logf("[DEBUG] Getting properties for folder 'test' ..")
+	props, err := pathsClient.GetProperties(ctx, fileSystemName, path, GetPropertiesInput{Action: GetPropertiesActionGetAccessControl})
+	if err != nil {
+		t.Fatal(fmt.Errorf("error getting properties: %s", err))
+	}
+	t.Logf("[DEBUG] Props.Owner: %q", props.Owner)
+	t.Logf("[DEBUG] Props.Group: %q", props.Group)
+	t.Logf("[DEBUG] Props.ACL: %q", props.ACL)
+	t.Logf("[DEBUG] Props.ETag: %q", props.ETag)
+	t.Logf("[DEBUG] Props.LastModified: %q", props.LastModified)
+	if props.ACL != defaultACLString {
+		t.Fatal(fmt.Errorf("Expected Default ACL %q, got %q", defaultACLString, props.ACL))
+	}
+
+	newACL := "user::rwx,group::r-x,other::r-x,default:user::rwx,default:group::r-x,default:other::---"
+	accessControlInput := SetAccessControlInput{
+		ACL: &newACL,
+	}
+	t.Logf("[DEBUG] Setting Access Control for folder 'test' ..")
+	if _, err = pathsClient.SetAccessControl(ctx, fileSystemName, path, accessControlInput); err != nil {
+		t.Fatal(fmt.Errorf("error setting Access Control %s", err))
+	}
+
+	t.Logf("[DEBUG] Getting properties for folder 'test' (2) ..")
+	props, err = pathsClient.GetProperties(ctx, fileSystemName, path, GetPropertiesInput{Action: GetPropertiesActionGetAccessControl})
+	if err != nil {
+		t.Fatal(fmt.Errorf("error getting properties (2): %s", err))
+	}
+	if props.ACL != newACL {
+		t.Fatal(fmt.Errorf("expected new ACL %q, got %q", newACL, props.ACL))
+	}
+
+	t.Logf("[DEBUG] Deleting path 'test' ..")
+	if _, err = pathsClient.Delete(ctx, fileSystemName, path); err != nil {
+		t.Fatal(fmt.Errorf("error deleting path: %s", err))
+	}
+
+	t.Logf("[DEBUG] Getting properties for folder 'test' (3) ..")
+	props, err = pathsClient.GetProperties(ctx, fileSystemName, path, GetPropertiesInput{Action: GetPropertiesActionGetAccessControl})
+	if err == nil {
+		t.Fatal(fmt.Errorf("didn't get error getting properties after deleting path (3)"))
+	}
+
+	t.Logf("[DEBUG] Deleting File System..")
+	if _, err := fileSystemsClient.Delete(ctx, fileSystemName); err != nil {
+		t.Fatalf("Error deleting filesystem: %s", err)
+	}
+}

--- a/storage/2026-02-06/datalakestore/paths/lifecycle_test.go
+++ b/storage/2026-02-06/datalakestore/paths/lifecycle_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
-	"github.com/jackofallops/giovanni/storage/2020-08-04/datalakestore/filesystems"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/datalakestore/filesystems"
 	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
 )
 

--- a/storage/2026-02-06/datalakestore/paths/properties_get.go
+++ b/storage/2026-02-06/datalakestore/paths/properties_get.go
@@ -1,0 +1,111 @@
+package paths
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type GetPropertiesResponse struct {
+	HttpResponse *http.Response
+
+	ETag         string
+	LastModified time.Time
+	// ResourceType is only returned for GetPropertiesActionGetStatus requests
+	ResourceType PathResource
+	Owner        string
+	Group        string
+	// ACL is only returned for GetPropertiesActionGetAccessControl requests
+	ACL string
+}
+
+type GetPropertiesInput struct {
+	Action GetPropertiesAction
+}
+
+type GetPropertiesAction string
+
+const (
+	GetPropertiesActionGetStatus        GetPropertiesAction = "getStatus"
+	GetPropertiesActionGetAccessControl GetPropertiesAction = "getAccessControl"
+)
+
+// GetProperties gets the properties for a Data Lake Store Gen2 Path in a FileSystem within a Storage Account
+func (c Client) GetProperties(ctx context.Context, fileSystemName string, path string, input GetPropertiesInput) (result GetPropertiesResponse, err error) {
+	if fileSystemName == "" {
+		err = fmt.Errorf("`fileSystemName` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodHead,
+		OptionsObject: getPropertyOptions{
+			action: input.Action,
+		},
+		Path: fmt.Sprintf("/%s/%s", fileSystemName, path),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return result, err
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.ResourceType = PathResource(resp.Header.Get("x-ms-resource-type"))
+				result.ETag = resp.Header.Get("ETag")
+
+				if lastModifiedRaw := resp.Header.Get("Last-Modified"); lastModifiedRaw != "" {
+					lastModified, err := time.Parse(time.RFC1123, lastModifiedRaw)
+					if err != nil {
+						return GetPropertiesResponse{}, err
+					}
+					result.LastModified = lastModified
+				}
+
+				result.Owner = resp.Header.Get("x-ms-owner")
+				result.Group = resp.Header.Get("x-ms-group")
+				result.ACL = resp.Header.Get("x-ms-acl")
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return result, err
+	}
+
+	return
+}
+
+type getPropertyOptions struct {
+	action GetPropertiesAction
+}
+
+func (g getPropertyOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (g getPropertyOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (g getPropertyOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("action", string(g.action))
+	return out
+}

--- a/storage/2026-02-06/datalakestore/paths/properties_set.go
+++ b/storage/2026-02-06/datalakestore/paths/properties_set.go
@@ -1,0 +1,107 @@
+package paths
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type SetAccessControlInput struct {
+	Owner *string
+	Group *string
+	ACL   *string
+
+	// Optional - A date and time value.
+	// Specify this header to perform the operation only if the resource has been modified since the specified date and time.
+	IfModifiedSince *string
+
+	// Optional - A date and time value.
+	// Specify this header to perform the operation only if the resource has not been modified since the specified date and time.
+	IfUnmodifiedSince *string
+}
+
+type SetPropertiesResponse struct {
+	HttpResponse *http.Response
+}
+
+// SetAccessControl sets the access control properties for a Data Lake Store Gen2 Path within a Storage Account File System
+func (c Client) SetAccessControl(ctx context.Context, fileSystemName string, path string, input SetAccessControlInput) (result SetPropertiesResponse, err error) {
+	if fileSystemName == "" {
+		err = fmt.Errorf("`fileSystemName` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPatch,
+		OptionsObject: setPropertyOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", fileSystemName, path),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return result, err
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return result, err
+	}
+
+	return
+}
+
+type setPropertyOptions struct {
+	input SetAccessControlInput
+}
+
+func (s setPropertyOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	if s.input.ACL != nil {
+		headers.Append("x-ms-acl", *s.input.ACL)
+	}
+
+	if s.input.Owner != nil {
+		headers.Append("x-ms-owner", *s.input.Owner)
+	}
+
+	if s.input.Group != nil {
+		headers.Append("x-ms-group", *s.input.Group)
+	}
+
+	if s.input.IfModifiedSince != nil {
+		headers.Append("If-Modified-Since", *s.input.IfModifiedSince)
+	}
+
+	if s.input.IfUnmodifiedSince != nil {
+		headers.Append("If-Unmodified-Since", *s.input.IfUnmodifiedSince)
+	}
+
+	return headers
+}
+
+func (s setPropertyOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (s setPropertyOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("action", "setAccessControl")
+	return out
+}

--- a/storage/2026-02-06/datalakestore/paths/resource_id.go
+++ b/storage/2026-02-06/datalakestore/paths/resource_id.go
@@ -1,0 +1,80 @@
+package paths
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+// TODO: update this to implement `resourceids.ResourceId` once
+// https://github.com/hashicorp/go-azure-helpers/issues/187 is fixed
+var _ resourceids.Id = PathId{}
+
+type PathId struct {
+	// AccountId specifies the ID of the Storage Account where this path exists.
+	AccountId accounts.AccountId
+
+	// FileSystemName specifies the name of the Data Lake FileSystem where this Path exists.
+	FileSystemName string
+
+	// Path specifies the path in question.
+	Path string
+}
+
+func NewPathID(accountId accounts.AccountId, fileSystemName, path string) PathId {
+	return PathId{
+		AccountId:      accountId,
+		FileSystemName: fileSystemName,
+		Path:           path,
+	}
+}
+
+func (b PathId) ID() string {
+	return fmt.Sprintf("%s/%s/%s", b.AccountId.ID(), b.FileSystemName, b.Path)
+}
+
+func (b PathId) String() string {
+	components := []string{
+		fmt.Sprintf("File System %q", b.FileSystemName),
+		fmt.Sprintf("Account %q", b.AccountId.String()),
+	}
+	return fmt.Sprintf("Path %q (%s)", b.Path, strings.Join(components, " / "))
+}
+
+// ParsePathID parses `input` into a Path ID using a known `domainSuffix`
+func ParsePathID(input, domainSuffix string) (*PathId, error) {
+	// example: https://foo.dfs.core.windows.net/Bar/some/path
+	if input == "" {
+		return nil, fmt.Errorf("`input` was empty")
+	}
+
+	account, err := accounts.ParseAccountID(input, domainSuffix)
+	if err != nil {
+		return nil, fmt.Errorf("parsing account %q: %+v", input, err)
+	}
+
+	if account.SubDomainType != accounts.DataLakeStoreSubDomainType {
+		return nil, fmt.Errorf("expected the subdomain type to be %q but got %q", string(accounts.DataLakeStoreSubDomainType), string(account.SubDomainType))
+	}
+
+	uri, err := url.Parse(input)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q as a uri: %+v", input, err)
+	}
+
+	uriPath := strings.TrimPrefix(uri.Path, "/")
+	segments := strings.Split(uriPath, "/")
+	if len(segments) < 2 {
+		return nil, fmt.Errorf("expected the path to contain at least 2 segments but got %d", len(segments))
+	}
+	fileSystemName := segments[0]
+	path := strings.Join(segments[1:], "/")
+	return &PathId{
+		AccountId:      *account,
+		FileSystemName: fileSystemName,
+		Path:           path,
+	}, nil
+}

--- a/storage/2026-02-06/datalakestore/paths/resource_id_test.go
+++ b/storage/2026-02-06/datalakestore/paths/resource_id_test.go
@@ -1,0 +1,169 @@
+package paths
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+func TestParsePathIDStandard(t *testing.T) {
+	input := "https://example1.dfs.core.windows.net/fileSystem1/some/path"
+	expected := PathId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.DataLakeStoreSubDomainType,
+			DomainSuffix:  "core.windows.net",
+		},
+		FileSystemName: "fileSystem1",
+		Path:           "some/path",
+	}
+	actual, err := ParsePathID(input, "core.windows.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if actual.FileSystemName != expected.FileSystemName {
+		t.Fatalf("expected FileSystemName to be %q but got %q", expected.FileSystemName, actual.FileSystemName)
+	}
+	if actual.Path != expected.Path {
+		t.Fatalf("expected Path to be %q but got %q", expected.Path, actual.Path)
+	}
+}
+
+func TestParsePathIDInADNSZone(t *testing.T) {
+	input := "https://example1.zone1.dfs.storage.azure.net/fileSystem1/some/path"
+	expected := PathId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.DataLakeStoreSubDomainType,
+			DomainSuffix:  "storage.azure.net",
+			ZoneName:      pointer.To("zone1"),
+		},
+		FileSystemName: "fileSystem1",
+		Path:           "some/path",
+	}
+	actual, err := ParsePathID(input, "storage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if pointer.From(actual.AccountId.ZoneName) != pointer.From(expected.AccountId.ZoneName) {
+		t.Fatalf("expected ZoneName to be %q but got %q", pointer.From(expected.AccountId.ZoneName), pointer.From(actual.AccountId.ZoneName))
+	}
+	if actual.FileSystemName != expected.FileSystemName {
+		t.Fatalf("expected FileSystemName to be %q but got %q", expected.FileSystemName, actual.FileSystemName)
+	}
+	if actual.Path != expected.Path {
+		t.Fatalf("expected Path to be %q but got %q", expected.Path, actual.Path)
+	}
+}
+
+func TestParsePathIDInAnEdgeZone(t *testing.T) {
+	input := "https://example1.dfs.zone1.edgestorage.azure.net/fileSystem1/some/path"
+	expected := PathId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.DataLakeStoreSubDomainType,
+			DomainSuffix:  "edgestorage.azure.net",
+			ZoneName:      pointer.To("zone1"),
+			IsEdgeZone:    true,
+		},
+		FileSystemName: "fileSystem1",
+		Path:           "some/path",
+	}
+	actual, err := ParsePathID(input, "edgestorage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if pointer.From(actual.AccountId.ZoneName) != pointer.From(expected.AccountId.ZoneName) {
+		t.Fatalf("expected ZoneName to be %q but got %q", pointer.From(expected.AccountId.ZoneName), pointer.From(actual.AccountId.ZoneName))
+	}
+	if !actual.AccountId.IsEdgeZone {
+		t.Fatalf("expected the Account to be in an Edge Zone but it wasn't")
+	}
+	if actual.FileSystemName != expected.FileSystemName {
+		t.Fatalf("expected FileSystemName to be %q but got %q", expected.FileSystemName, actual.FileSystemName)
+	}
+	if actual.Path != expected.Path {
+		t.Fatalf("expected Path to be %q but got %q", expected.Path, actual.Path)
+	}
+}
+
+func TestFormatPathIDStandard(t *testing.T) {
+	actual := PathId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.DataLakeStoreSubDomainType,
+			DomainSuffix:  "core.windows.net",
+			IsEdgeZone:    false,
+		},
+		FileSystemName: "fileSystem1",
+		Path:           "some/path",
+	}.ID()
+	expected := "https://example1.dfs.core.windows.net/fileSystem1/some/path"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatPathIDInDNSZone(t *testing.T) {
+	actual := PathId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			ZoneName:      pointer.To("zone2"),
+			SubDomainType: accounts.DataLakeStoreSubDomainType,
+			DomainSuffix:  "storage.azure.net",
+			IsEdgeZone:    false,
+		},
+		FileSystemName: "fileSystem1",
+		Path:           "some/path",
+	}.ID()
+	expected := "https://example1.zone2.dfs.storage.azure.net/fileSystem1/some/path"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatPathIDInEdgeZone(t *testing.T) {
+	actual := PathId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			ZoneName:      pointer.To("zone2"),
+			SubDomainType: accounts.DataLakeStoreSubDomainType,
+			DomainSuffix:  "edgestorage.azure.net",
+			IsEdgeZone:    true,
+		},
+		FileSystemName: "fileSystem1",
+		Path:           "some",
+	}.ID()
+	expected := "https://example1.dfs.zone2.edgestorage.azure.net/fileSystem1/some"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}

--- a/storage/2026-02-06/datalakestore/paths/version.go
+++ b/storage/2026-02-06/datalakestore/paths/version.go
@@ -1,0 +1,4 @@
+package paths
+
+const apiVersion = "2026-02-06"
+const componentName = "datalakestore/paths"

--- a/storage/2026-02-06/file/directories/README.md
+++ b/storage/2026-02-06/file/directories/README.md
@@ -1,0 +1,59 @@
+## File Storage Directories SDK for API version 2026-02-06
+
+This package allows you to interact with the Directories File Storage API
+
+### Supported Authorizers
+
+* Azure Active Directory (for the Resource Endpoint `https://storage.azure.com`)
+* SharedKeyLite (Blob, File & Queue)
+
+### Limitations
+
+* At this time the headers `x-ms-file-permission` and `x-ms-file-attributes` are hard-coded (to `inherit` and `None`, respectively).
+
+### Example Usage
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/file/directories"
+)
+
+func Example() error {
+	accountName := "storageaccount1"
+    storageAccountKey := "ABC123...."
+    shareName := "myshare"
+    directoryName := "myfiles"
+	domainSuffix := "core.windows.net"
+
+	auth, err := auth.NewSharedKeyAuthorizer(accountName, storageAccountKey, auth.SharedKey)
+	if err != nil {
+		return fmt.Errorf("building SharedKey authorizer: %+v", err)
+	}
+	
+    directoriesClient, err := directories.NewWithBaseUri(fmt.Sprintf("https://%s.dfs.%s", accountName, domainSuffix))
+	if err != nil {
+		return fmt.Errorf("building client for environment: %+v", err)
+	}
+    directoriesClient.Client.SetAuthorizer(auth)
+    
+    ctx := context.TODO()
+    metadata := map[string]string{
+    	"hello": "world",
+    }
+	
+	input := directories.CreateDirectoryInput{
+		MetaData: metadata,
+    }
+    if _, err := directoriesClient.Create(ctx, shareName, directoryName, input); err != nil {
+        return fmt.Errorf("Error creating Directory: %s", err)
+    }
+    
+    return nil 
+}
+```

--- a/storage/2026-02-06/file/directories/api.go
+++ b/storage/2026-02-06/file/directories/api.go
@@ -1,0 +1,13 @@
+package directories
+
+import (
+	"context"
+)
+
+type StorageDirectory interface {
+	Delete(ctx context.Context, shareName, path string) (resp DeleteResponse, err error)
+	GetMetaData(ctx context.Context, shareName, path string) (resp GetMetaDataResponse, err error)
+	SetMetaData(ctx context.Context, shareName, path string, input SetMetaDataInput) (resp SetMetaDataResponse, err error)
+	Create(ctx context.Context, shareName, path string, input CreateDirectoryInput) (resp CreateDirectoryResponse, err error)
+	Get(ctx context.Context, shareName, path string) (resp GetResponse, err error)
+}

--- a/storage/2026-02-06/file/directories/client.go
+++ b/storage/2026-02-06/file/directories/client.go
@@ -1,0 +1,39 @@
+package directories
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/dataplane/storage"
+)
+
+// Client is the base client for File Storage Shares.
+type Client struct {
+	Client *storage.Client
+}
+
+func NewWithBaseUri(baseUri string) (*Client, error) {
+	baseClient, err := storage.NewStorageClient(baseUri, componentName, apiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("building base client: %+v", err)
+	}
+
+	baseClient.Client.AuthorizeRequest = func(ctx context.Context, req *http.Request, authorizer auth.Authorizer) error {
+		if err := auth.SetAuthHeader(ctx, req, authorizer); err != nil {
+			return fmt.Errorf("authorizing request: %+v", err)
+		}
+
+		// Only set this header if OAuth is being used (i.e. not shared key authentication)
+		if _, ok := authorizer.(*auth.SharedKeyAuthorizer); !ok {
+			req.Header.Set("x-ms-file-request-intent", "backup")
+		}
+
+		return nil
+	}
+
+	return &Client{
+		Client: baseClient,
+	}, nil
+}

--- a/storage/2026-02-06/file/directories/create.go
+++ b/storage/2026-02-06/file/directories/create.go
@@ -1,0 +1,123 @@
+package directories
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type CreateDirectoryInput struct {
+	// The time at which this file was created at - if omitted, this'll be set to "now"
+	// This maps to the `x-ms-file-creation-time` field.
+	// ... Yes I know it says File not Directory, I didn't design the API.
+	CreatedAt *time.Time
+
+	// The time at which this file was last modified - if omitted, this'll be set to "now"
+	// This maps to the `x-ms-file-last-write-time` field.
+	// ... Yes I know it says File not Directory, I didn't design the API.
+	LastModified *time.Time
+
+	// MetaData is a mapping of key value pairs which should be assigned to this directory
+	MetaData map[string]string
+}
+
+type CreateDirectoryResponse struct {
+	HttpResponse *http.Response
+}
+
+// Create creates a new directory under the specified share or parent directory.
+func (c Client) Create(ctx context.Context, shareName, path string, input CreateDirectoryInput) (result CreateDirectoryResponse, err error) {
+
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if err = metadata.Validate(input.MetaData); err != nil {
+		err = fmt.Errorf("`input.MetaData` is not valid: %s", err)
+		return
+	}
+
+	if path == "" {
+		err = fmt.Errorf("`path` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: CreateOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s", shareName, path),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type CreateOptions struct {
+	input CreateDirectoryInput
+}
+
+func (c CreateOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	if len(c.input.MetaData) > 0 {
+		headers.Merge(metadata.SetMetaDataHeaders(c.input.MetaData))
+	}
+
+	var coalesceDate = func(input *time.Time, defaultVal string) string {
+		if input == nil {
+			return defaultVal
+		}
+		return input.Format(time.RFC1123)
+	}
+
+	// ... Yes I know these say File not Directory, I didn't design the API.
+	headers.Append("x-ms-file-permission", "inherit") // TODO: expose this in future
+	headers.Append("x-ms-file-attributes", "None")    // TODO: expose this in future
+	headers.Append("x-ms-file-creation-time", coalesceDate(c.input.CreatedAt, "now"))
+	headers.Append("x-ms-file-last-write-time", coalesceDate(c.input.LastModified, "now"))
+
+	return headers
+}
+
+func (c CreateOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (c CreateOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("restype", "directory")
+	return out
+}

--- a/storage/2026-02-06/file/directories/delete.go
+++ b/storage/2026-02-06/file/directories/delete.go
@@ -1,0 +1,92 @@
+package directories
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type DeleteResponse struct {
+	HttpResponse *http.Response
+}
+
+// Delete removes the specified empty directory
+// Note that the directory must be empty before it can be deleted.
+func (c Client) Delete(ctx context.Context, shareName, path string) (result DeleteResponse, err error) {
+
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if path == "" {
+		err = fmt.Errorf("`path` cannot be an empty string")
+		return
+	}
+
+	// Retry the directory deletion if the directory is not empty (deleted files take a little while to disappear)
+	retryFunc := func(resp *http.Response, _ *odata.OData) (bool, error) {
+		if resp != nil {
+			if response.WasStatusCode(resp, http.StatusConflict) {
+				// TODO: move this error response parsing to a common helper function
+				respBody, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return false, fmt.Errorf("could not parse response body")
+				}
+				resp.Body.Close()
+				respBody = bytes.TrimPrefix(respBody, []byte("\xef\xbb\xbf"))
+				res := ErrorResponse{}
+				if err = xml.Unmarshal(respBody, &res); err != nil {
+					return false, err
+				}
+				resp.Body = io.NopCloser(bytes.NewBuffer(respBody))
+				if res.Code != nil {
+					return strings.Contains(*res.Code, "DirectoryNotEmpty"), nil
+				}
+			}
+		}
+		return false, nil
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+		},
+		HttpMethod:    http.MethodDelete,
+		OptionsObject: directoriesOptions{},
+		Path:          fmt.Sprintf("/%s/%s", shareName, path),
+		RetryFunc:     retryFunc,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}

--- a/storage/2026-02-06/file/directories/get.go
+++ b/storage/2026-02-06/file/directories/get.go
@@ -1,0 +1,76 @@
+package directories
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type GetResponse struct {
+	HttpResponse *http.Response
+
+	// A set of name-value pairs that contain metadata for the directory.
+	MetaData map[string]string
+
+	// The value of this header is set to true if the directory metadata is completely
+	// encrypted using the specified algorithm. Otherwise, the value is set to false.
+	DirectoryMetaDataEncrypted bool
+}
+
+// Get returns all system properties for the specified directory,
+// and can also be used to check the existence of a directory.
+func (c Client) Get(ctx context.Context, shareName, path string) (result GetResponse, err error) {
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if path == "" {
+		err = fmt.Errorf("`path` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: directoriesOptions{},
+		Path:          fmt.Sprintf("/%s/%s", shareName, path),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.DirectoryMetaDataEncrypted = strings.EqualFold(resp.Header.Get("x-ms-server-encrypted"), "true")
+				result.MetaData = metadata.ParseFromHeaders(resp.Header)
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}

--- a/storage/2026-02-06/file/directories/lifecycle_test.go
+++ b/storage/2026-02-06/file/directories/lifecycle_test.go
@@ -1,0 +1,123 @@
+package directories
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2020-08-04/file/shares"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+var StorageFile = Client{}
+
+func TestDirectoriesLifeCycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	shareName := fmt.Sprintf("share-%d", testhelpers.RandomInt())
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+	sharesClient, err := shares.NewWithBaseUri(fmt.Sprintf("https://%s.file.%s", accountName, *domainSuffix))
+	if err := client.PrepareWithSharedKeyAuth(sharesClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	directoriesClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.file.%s", accountName, *domainSuffix))
+	if err := client.PrepareWithSharedKeyAuth(directoriesClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	input := shares.CreateInput{
+		QuotaInGB: 1,
+	}
+	_, err = sharesClient.Create(ctx, shareName, input)
+	if err != nil {
+		t.Fatalf("Error creating fileshare: %s", err)
+	}
+	defer sharesClient.Delete(ctx, shareName, shares.DeleteInput{DeleteSnapshots: true})
+
+	metaData := map[string]string{
+		"hello": "world",
+	}
+
+	log.Printf("[DEBUG] Creating Top Level..")
+	createInput := CreateDirectoryInput{
+		MetaData: metaData,
+	}
+	if _, err := directoriesClient.Create(ctx, shareName, "hello", createInput); err != nil {
+		t.Fatalf("Error creating Top Level Directory: %s", err)
+	}
+
+	log.Printf("[DEBUG] Creating Inner..")
+	if _, err := directoriesClient.Create(ctx, shareName, "hello/there", createInput); err != nil {
+		t.Fatalf("Error creating Inner Directory: %s", err)
+	}
+
+	log.Printf("[DEBUG] Retrieving share")
+	innerDir, err := directoriesClient.Get(ctx, shareName, "hello/there")
+	if err != nil {
+		t.Fatalf("Error retrieving Inner Directory: %s", err)
+	}
+
+	if innerDir.DirectoryMetaDataEncrypted != true {
+		t.Fatalf("Expected MetaData to be encrypted but got: %t", innerDir.DirectoryMetaDataEncrypted)
+	}
+
+	if len(innerDir.MetaData) != 1 {
+		t.Fatalf("Expected MetaData to contain 1 item but got %d", len(innerDir.MetaData))
+	}
+	if innerDir.MetaData["hello"] != "world" {
+		t.Fatalf("Expected MetaData `hello` to be `world`: %s", innerDir.MetaData["hello"])
+	}
+
+	log.Printf("[DEBUG] Setting MetaData")
+	updatedMetaData := map[string]string{
+		"panda": "pops",
+	}
+	if _, err := directoriesClient.SetMetaData(ctx, shareName, "hello/there", SetMetaDataInput{MetaData: updatedMetaData}); err != nil {
+		t.Fatalf("Error updating MetaData: %s", err)
+	}
+
+	log.Printf("[DEBUG] Retrieving MetaData")
+	retrievedMetaData, err := directoriesClient.GetMetaData(ctx, shareName, "hello/there")
+	if err != nil {
+		t.Fatalf("Error retrieving the updated metadata: %s", err)
+	}
+	if len(retrievedMetaData.MetaData) != 1 {
+		t.Fatalf("Expected the updated metadata to have 1 item but got %d", len(retrievedMetaData.MetaData))
+	}
+	if retrievedMetaData.MetaData["panda"] != "pops" {
+		t.Fatalf("Expected the metadata `panda` to be `pops` but got %q", retrievedMetaData.MetaData["panda"])
+	}
+
+	t.Logf("[DEBUG] Deleting Inner..")
+	if _, err := directoriesClient.Delete(ctx, shareName, "hello/there"); err != nil {
+		t.Fatalf("Error deleting Inner Directory: %s", err)
+	}
+
+	t.Logf("[DEBUG] Deleting Top Level..")
+	if _, err := directoriesClient.Delete(ctx, shareName, "hello"); err != nil {
+		t.Fatalf("Error deleting Top Level Directory: %s", err)
+	}
+}

--- a/storage/2026-02-06/file/directories/lifecycle_test.go
+++ b/storage/2026-02-06/file/directories/lifecycle_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
-	"github.com/jackofallops/giovanni/storage/2020-08-04/file/shares"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/file/shares"
 	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
 )
 

--- a/storage/2026-02-06/file/directories/metadata_get.go
+++ b/storage/2026-02-06/file/directories/metadata_get.go
@@ -1,0 +1,87 @@
+package directories
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type GetMetaDataResponse struct {
+	HttpResponse *http.Response
+
+	MetaData map[string]string
+}
+
+// GetMetaData returns all user-defined metadata for the specified directory
+func (c Client) GetMetaData(ctx context.Context, shareName, path string) (result GetMetaDataResponse, err error) {
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if path == "" {
+		err = fmt.Errorf("`path` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: GetMetaDataOptions{},
+		Path:          fmt.Sprintf("/%s/%s", shareName, path),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.MetaData = metadata.ParseFromHeaders(resp.Header)
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type GetMetaDataOptions struct{}
+
+func (g GetMetaDataOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (g GetMetaDataOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (g GetMetaDataOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("restype", "directory")
+	out.Append("comp", "metadata")
+	return out
+}

--- a/storage/2026-02-06/file/directories/metadata_set.go
+++ b/storage/2026-02-06/file/directories/metadata_set.go
@@ -1,0 +1,98 @@
+package directories
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type SetMetaDataResponse struct {
+	HttpResponse *http.Response
+}
+
+type SetMetaDataInput struct {
+	MetaData map[string]string
+}
+
+// SetMetaData updates user defined metadata for the specified directory
+func (c Client) SetMetaData(ctx context.Context, shareName, path string, input SetMetaDataInput) (result SetMetaDataResponse, err error) {
+
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if err = metadata.Validate(input.MetaData); err != nil {
+		err = fmt.Errorf("`metadata` is not valid: %s", err)
+		return
+	}
+
+	if path == "" {
+		err = fmt.Errorf("`path` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: SetMetaDataOptions{
+			metaData: input.MetaData,
+		},
+		Path: fmt.Sprintf("/%s/%s", shareName, path),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type SetMetaDataOptions struct {
+	metaData map[string]string
+}
+
+func (s SetMetaDataOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	if len(s.metaData) > 0 {
+		headers.Merge(metadata.SetMetaDataHeaders(s.metaData))
+	}
+	return headers
+}
+
+func (s SetMetaDataOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (s SetMetaDataOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("restype", "directory")
+	out.Append("comp", "metadata")
+	return out
+}

--- a/storage/2026-02-06/file/directories/models.go
+++ b/storage/2026-02-06/file/directories/models.go
@@ -1,0 +1,9 @@
+package directories
+
+import "encoding/xml"
+
+type ErrorResponse struct {
+	XMLName xml.Name `xml:"Error"`
+	Code    *string  `xml:"Code"`
+	Message *string  `xml:"Message"`
+}

--- a/storage/2026-02-06/file/directories/options.go
+++ b/storage/2026-02-06/file/directories/options.go
@@ -1,0 +1,24 @@
+package directories
+
+import (
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+var _ client.Options = directoriesOptions{}
+
+type directoriesOptions struct{}
+
+func (o directoriesOptions) ToHeaders() *client.Headers {
+	return &client.Headers{}
+}
+
+func (directoriesOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (directoriesOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("restype", "directory")
+	return out
+}

--- a/storage/2026-02-06/file/directories/resource_id.go
+++ b/storage/2026-02-06/file/directories/resource_id.go
@@ -1,0 +1,80 @@
+package directories
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+// TODO: update this to implement `resourceids.ResourceId` once
+// https://github.com/hashicorp/go-azure-helpers/issues/187 is fixed
+var _ resourceids.Id = DirectoryId{}
+
+type DirectoryId struct {
+	// AccountId specifies the ID of the Storage Account where this Directory exists.
+	AccountId accounts.AccountId
+
+	// ShareName specifies the name of the File Share containing this Directory.
+	ShareName string
+
+	// DirectoryPath specifies the path representing this Directory.
+	DirectoryPath string
+}
+
+func NewDirectoryID(accountId accounts.AccountId, shareName, directoryPath string) DirectoryId {
+	return DirectoryId{
+		AccountId:     accountId,
+		ShareName:     shareName,
+		DirectoryPath: directoryPath,
+	}
+}
+
+func (b DirectoryId) ID() string {
+	return fmt.Sprintf("%s/%s/%s", b.AccountId.ID(), b.ShareName, b.DirectoryPath)
+}
+
+func (b DirectoryId) String() string {
+	components := []string{
+		fmt.Sprintf("Share Name %q", b.ShareName),
+		fmt.Sprintf("Account %q", b.AccountId.String()),
+	}
+	return fmt.Sprintf("Directory Path %q (%s)", b.DirectoryPath, strings.Join(components, " / "))
+}
+
+// ParseDirectoryID parses `input` into a Directory ID using a known `domainSuffix`
+func ParseDirectoryID(input, domainSuffix string) (*DirectoryId, error) {
+	// example: https://foo.file.core.windows.net/Bar/some/directory
+	if input == "" {
+		return nil, fmt.Errorf("`input` was empty")
+	}
+
+	account, err := accounts.ParseAccountID(input, domainSuffix)
+	if err != nil {
+		return nil, fmt.Errorf("parsing account %q: %+v", input, err)
+	}
+
+	if account.SubDomainType != accounts.FileSubDomainType {
+		return nil, fmt.Errorf("expected the subdomain type to be %q but got %q", string(accounts.FileSubDomainType), string(account.SubDomainType))
+	}
+
+	uri, err := url.Parse(input)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q as a uri: %+v", input, err)
+	}
+
+	path := strings.TrimPrefix(uri.Path, "/")
+	segments := strings.Split(path, "/")
+	if len(segments) < 2 {
+		return nil, fmt.Errorf("expected the path to contain at least 2 segments but got %d", len(segments))
+	}
+	shareName := segments[0]
+	directoryPath := strings.Join(segments[1:], "/")
+	return &DirectoryId{
+		AccountId:     *account,
+		ShareName:     shareName,
+		DirectoryPath: directoryPath,
+	}, nil
+}

--- a/storage/2026-02-06/file/directories/resource_id_test.go
+++ b/storage/2026-02-06/file/directories/resource_id_test.go
@@ -1,0 +1,169 @@
+package directories
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+func TestParseDirectoryIDStandard(t *testing.T) {
+	input := "https://example1.file.core.windows.net/share1/some/path"
+	expected := DirectoryId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.FileSubDomainType,
+			DomainSuffix:  "core.windows.net",
+		},
+		ShareName:     "share1",
+		DirectoryPath: "some/path",
+	}
+	actual, err := ParseDirectoryID(input, "core.windows.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if actual.ShareName != expected.ShareName {
+		t.Fatalf("expected ShareName to be %q but got %q", expected.ShareName, actual.ShareName)
+	}
+	if actual.DirectoryPath != expected.DirectoryPath {
+		t.Fatalf("expected DirectoryPath to be %q but got %q", expected.DirectoryPath, actual.DirectoryPath)
+	}
+}
+
+func TestParseDirectoryIDInADNSZone(t *testing.T) {
+	input := "https://example1.zone1.file.storage.azure.net/share1/path"
+	expected := DirectoryId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.FileSubDomainType,
+			DomainSuffix:  "storage.azure.net",
+			ZoneName:      pointer.To("zone1"),
+		},
+		ShareName:     "share1",
+		DirectoryPath: "path",
+	}
+	actual, err := ParseDirectoryID(input, "storage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if pointer.From(actual.AccountId.ZoneName) != pointer.From(expected.AccountId.ZoneName) {
+		t.Fatalf("expected ZoneName to be %q but got %q", pointer.From(expected.AccountId.ZoneName), pointer.From(actual.AccountId.ZoneName))
+	}
+	if actual.ShareName != expected.ShareName {
+		t.Fatalf("expected ShareName to be %q but got %q", expected.ShareName, actual.ShareName)
+	}
+	if actual.DirectoryPath != expected.DirectoryPath {
+		t.Fatalf("expected DirectoryPath to be %q but got %q", expected.DirectoryPath, actual.DirectoryPath)
+	}
+}
+
+func TestParseDirectoryIDInAnEdgeZone(t *testing.T) {
+	input := "https://example1.file.zone1.edgestorage.azure.net/share1/some/path"
+	expected := DirectoryId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.FileSubDomainType,
+			DomainSuffix:  "edgestorage.azure.net",
+			ZoneName:      pointer.To("zone1"),
+			IsEdgeZone:    true,
+		},
+		ShareName:     "share1",
+		DirectoryPath: "some/path",
+	}
+	actual, err := ParseDirectoryID(input, "edgestorage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if pointer.From(actual.AccountId.ZoneName) != pointer.From(expected.AccountId.ZoneName) {
+		t.Fatalf("expected ZoneName to be %q but got %q", pointer.From(expected.AccountId.ZoneName), pointer.From(actual.AccountId.ZoneName))
+	}
+	if !actual.AccountId.IsEdgeZone {
+		t.Fatalf("expected the Account to be in an Edge Zone but it wasn't")
+	}
+	if actual.ShareName != expected.ShareName {
+		t.Fatalf("expected ShareName to be %q but got %q", expected.ShareName, actual.ShareName)
+	}
+	if actual.DirectoryPath != expected.DirectoryPath {
+		t.Fatalf("expected DirectoryPath to be %q but got %q", expected.DirectoryPath, actual.DirectoryPath)
+	}
+}
+
+func TestFormatContainerIDStandard(t *testing.T) {
+	actual := DirectoryId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.FileSubDomainType,
+			DomainSuffix:  "core.windows.net",
+			IsEdgeZone:    false,
+		},
+		ShareName:     "share1",
+		DirectoryPath: "some/path",
+	}.ID()
+	expected := "https://example1.file.core.windows.net/share1/some/path"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatContainerIDInDNSZone(t *testing.T) {
+	actual := DirectoryId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			ZoneName:      pointer.To("zone2"),
+			SubDomainType: accounts.FileSubDomainType,
+			DomainSuffix:  "storage.azure.net",
+			IsEdgeZone:    false,
+		},
+		ShareName:     "share1",
+		DirectoryPath: "some/path",
+	}.ID()
+	expected := "https://example1.zone2.file.storage.azure.net/share1/some/path"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatContainerIDInEdgeZone(t *testing.T) {
+	actual := DirectoryId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			ZoneName:      pointer.To("zone2"),
+			SubDomainType: accounts.FileSubDomainType,
+			DomainSuffix:  "edgestorage.azure.net",
+			IsEdgeZone:    true,
+		},
+		ShareName:     "share1",
+		DirectoryPath: "path",
+	}.ID()
+	expected := "https://example1.file.zone2.edgestorage.azure.net/share1/path"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}

--- a/storage/2026-02-06/file/directories/version.go
+++ b/storage/2026-02-06/file/directories/version.go
@@ -1,0 +1,5 @@
+package directories
+
+// APIVersion is the version of the API used for all Storage API Operations
+const apiVersion = "2026-02-06"
+const componentName = "file/directories"

--- a/storage/2026-02-06/file/files/README.md
+++ b/storage/2026-02-06/file/files/README.md
@@ -1,0 +1,54 @@
+## File Storage Files SDK for API version 2026-02-06
+
+This package allows you to interact with the Files File Storage API
+
+### Supported Authorizers
+
+* Azure Active Directory (for the Resource Endpoint `https://storage.azure.com`)
+* SharedKeyLite (Blob, File & Queue)
+
+### Limitations
+
+* At this time the headers `x-ms-file-permission` and `x-ms-file-attributes` are hard-coded (to `inherit` and `None`, respectively).
+
+### Example Usage
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/file/files"
+)
+
+func Example() error {
+	accountName := "storageaccount1"
+    storageAccountKey := "ABC123...."
+    shareName := "myshare"
+    directoryName := "myfiles"
+    fileName := "example.txt"
+	domainSuffix := "core.windows.net"
+
+	auth, err := auth.NewSharedKeyAuthorizer(accountName, storageAccountKey, auth.SharedKey)
+	if err != nil {
+		return fmt.Errorf("building SharedKey authorizer: %+v", err)
+	}
+	
+    filesClient, err := files.NewWithBaseUri(fmt.Sprintf("https://%s.file.%s", accountName, domainSuffix))
+	if err != nil {
+		return fmt.Errorf("building client for environment: %+v", err)
+	}
+    filesClient.Client.SetAuthorizer(auth)
+    
+    ctx := context.TODO()
+    input := files.CreateInput{}
+    if _, err := filesClient.Create(ctx, shareName, directoryName, fileName, input); err != nil {
+        return fmt.Errorf("Error creating File: %s", err)
+    }
+    
+    return nil 
+}
+```

--- a/storage/2026-02-06/file/files/api.go
+++ b/storage/2026-02-06/file/files/api.go
@@ -1,0 +1,24 @@
+package files
+
+import (
+	"context"
+	"os"
+)
+
+type StorageFile interface {
+	PutByteRange(ctx context.Context, shareName string, path string, fileName string, input PutByteRangeInput) (PutRangeResponse, error)
+	GetByteRange(ctx context.Context, shareName string, path string, fileName string, input GetByteRangeInput) (GetByteRangeResponse, error)
+	ClearByteRange(ctx context.Context, shareName string, path string, fileName string, input ClearByteRangeInput) (ClearByteRangeResponse, error)
+	SetProperties(ctx context.Context, shareName string, path string, fileName string, input SetPropertiesInput) (SetPropertiesResponse, error)
+	PutFile(ctx context.Context, shareName string, path string, fileName string, file *os.File, parallelism int) error
+	Copy(ctx context.Context, shareName, path, fileName string, input CopyInput) (CopyResponse, error)
+	SetMetaData(ctx context.Context, shareName string, path string, fileName string, input SetMetaDataInput) (SetMetaDataResponse, error)
+	GetMetaData(ctx context.Context, shareName string, path string, fileName string) (GetMetaDataResponse, error)
+	AbortCopy(ctx context.Context, shareName string, path string, fileName string, input CopyAbortInput) (CopyAbortResponse, error)
+	GetFile(ctx context.Context, shareName string, path string, fileName string, input GetFileInput) (GetFileResponse, error)
+	ListRanges(ctx context.Context, shareName, path, fileName string) (ListRangesResponse, error)
+	GetProperties(ctx context.Context, shareName string, path string, fileName string) (GetResponse, error)
+	Delete(ctx context.Context, shareName string, path string, fileName string) (DeleteResponse, error)
+	Create(ctx context.Context, shareName string, path string, fileName string, input CreateInput) (CreateResponse, error)
+	CopyAndWait(ctx context.Context, shareName, path, fileName string, input CopyInput) (CopyResponse, error)
+}

--- a/storage/2026-02-06/file/files/client.go
+++ b/storage/2026-02-06/file/files/client.go
@@ -1,0 +1,39 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/hashicorp/go-azure-sdk/sdk/client/dataplane/storage"
+)
+
+// Client is the base client for File Storage Shares.
+type Client struct {
+	Client *storage.Client
+}
+
+func NewWithBaseUri(baseUri string) (*Client, error) {
+	baseClient, err := storage.NewStorageClient(baseUri, componentName, apiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("building base client: %+v", err)
+	}
+
+	baseClient.Client.AuthorizeRequest = func(ctx context.Context, req *http.Request, authorizer auth.Authorizer) error {
+		if err := auth.SetAuthHeader(ctx, req, authorizer); err != nil {
+			return fmt.Errorf("authorizing request: %+v", err)
+		}
+
+		// Only set this header if OAuth is being used (i.e. not shared key authentication)
+		if _, ok := authorizer.(*auth.SharedKeyAuthorizer); !ok {
+			req.Header.Set("x-ms-file-request-intent", "backup")
+		}
+
+		return nil
+	}
+
+	return &Client{
+		Client: baseClient,
+	}, nil
+}

--- a/storage/2026-02-06/file/files/copy.go
+++ b/storage/2026-02-06/file/files/copy.go
@@ -1,0 +1,126 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type CopyInput struct {
+	// Specifies the URL of the source file or blob, up to 2 KB in length.
+	//
+	// To copy a file to another file within the same storage account, you may use Shared Key to authenticate
+	// the source file. If you are copying a file from another storage account, or if you are copying a blob from
+	// the same storage account or another storage account, then you must authenticate the source file or blob using a
+	// shared access signature. If the source is a public blob, no authentication is required to perform the copy
+	// operation. A file in a share snapshot can also be specified as a copy source.
+	CopySource string
+
+	MetaData map[string]string
+}
+
+type CopyResponse struct {
+	HttpResponse *http.Response
+
+	// The CopyID, which can be passed to AbortCopy to abort the copy.
+	CopyID string
+
+	// Either `success` or `pending`
+	CopySuccess string
+}
+
+// Copy copies a blob or file to a destination file within the storage account asynchronously.
+func (c Client) Copy(ctx context.Context, shareName, path, fileName string, input CopyInput) (result CopyResponse, err error) {
+
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if fileName == "" {
+		err = fmt.Errorf("`fileName` cannot be an empty string")
+		return
+	}
+
+	if input.CopySource == "" {
+		err = fmt.Errorf("`input.CopySource` cannot be an empty string")
+		return
+	}
+
+	if err = metadata.Validate(input.MetaData); err != nil {
+		err = fmt.Errorf("`input.MetaData` is not valid: %s", err)
+		return
+	}
+
+	if path != "" {
+		path = fmt.Sprintf("%s/", path)
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: CopyOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s%s", shareName, path, fileName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.CopyID = resp.Header.Get("x-ms-copy-id")
+				result.CopySuccess = resp.Header.Get("x-ms-copy-status")
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type CopyOptions struct {
+	input CopyInput
+}
+
+func (c CopyOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	if len(c.input.MetaData) > 0 {
+		headers.Merge(metadata.SetMetaDataHeaders(c.input.MetaData))
+	}
+	headers.Append("x-ms-copy-source", c.input.CopySource)
+	return headers
+}
+
+func (c CopyOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (c CopyOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/file/files/copy_abort.go
+++ b/storage/2026-02-06/file/files/copy_abort.go
@@ -1,0 +1,98 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type CopyAbortInput struct {
+	copyID string
+}
+
+type CopyAbortResponse struct {
+	HttpResponse *http.Response
+}
+
+// AbortCopy aborts a pending Copy File operation, and leaves a destination file with zero length and full metadata
+func (c Client) AbortCopy(ctx context.Context, shareName, path, fileName string, input CopyAbortInput) (result CopyAbortResponse, err error) {
+
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if fileName == "" {
+		err = fmt.Errorf("`fileName` cannot be an empty string")
+		return
+	}
+
+	if input.copyID == "" {
+		err = fmt.Errorf("`copyID` cannot be an empty string")
+		return
+	}
+
+	if path != "" {
+		path = fmt.Sprintf("%s/", path)
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: CopyAbortOptions{
+			copyId: input.copyID,
+		},
+		Path: fmt.Sprintf("/%s/%s%s", shareName, path, fileName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type CopyAbortOptions struct {
+	copyId string
+}
+
+func (c CopyAbortOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("x-ms-copy-action", "abort")
+	return headers
+}
+
+func (c CopyAbortOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (c CopyAbortOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "copy")
+	out.Append("copyid", c.copyId)
+	return out
+}

--- a/storage/2026-02-06/file/files/copy_and_wait_poller.go
+++ b/storage/2026-02-06/file/files/copy_and_wait_poller.go
@@ -1,0 +1,48 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+)
+
+var _ pollers.PollerType = &copyAndWaitPoller{}
+
+func NewCopyAndWaitPoller(client *Client, shareName, path, fileName string) *copyAndWaitPoller {
+	return &copyAndWaitPoller{
+		client:    client,
+		shareName: shareName,
+		path:      path,
+		fileName:  fileName,
+	}
+}
+
+type copyAndWaitPoller struct {
+	client    *Client
+	shareName string
+	path      string
+	fileName  string
+}
+
+func (p *copyAndWaitPoller) Poll(ctx context.Context) (*pollers.PollResult, error) {
+	props, err := p.client.GetProperties(ctx, p.shareName, p.path, p.fileName)
+	if err != nil {
+		return nil, fmt.Errorf("retrieving copy (shareName: %s path: %s fileName: %s) : %+v", p.shareName, p.path, p.fileName, err)
+	}
+
+	if strings.EqualFold(props.CopyStatus, "success") {
+		return &pollers.PollResult{
+			Status:       pollers.PollingStatusSucceeded,
+			PollInterval: 10 * time.Second,
+		}, nil
+	}
+
+	// Processing
+	return &pollers.PollResult{
+		Status:       pollers.PollingStatusInProgress,
+		PollInterval: 10 * time.Second,
+	}, nil
+}

--- a/storage/2026-02-06/file/files/copy_wait.go
+++ b/storage/2026-02-06/file/files/copy_wait.go
@@ -1,0 +1,29 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/pollers"
+)
+
+// CopyAndWait is a convenience method which doesn't exist in the API, which copies the file and then waits for the copy to complete
+func (c Client) CopyAndWait(ctx context.Context, shareName, path, fileName string, input CopyInput) (result CopyResponse, err error) {
+	fileCopy, e := c.Copy(ctx, shareName, path, fileName, input)
+	if err != nil {
+		result.HttpResponse = fileCopy.HttpResponse
+		err = fmt.Errorf("copying: %s", e)
+		return
+	}
+
+	result.CopyID = fileCopy.CopyID
+
+	pollerType := NewCopyAndWaitPoller(&c, shareName, path, fileName)
+	poller := pollers.NewPoller(pollerType, 10*time.Second, pollers.DefaultNumberOfDroppedConnectionsToAllow)
+	if err = poller.PollUntilDone(ctx); err != nil {
+		return result, fmt.Errorf("waiting for file to copy: %+v", err)
+	}
+
+	return
+}

--- a/storage/2026-02-06/file/files/copy_wait_test.go
+++ b/storage/2026-02-06/file/files/copy_wait_test.go
@@ -1,0 +1,150 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2020-08-04/file/shares"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+func TestFilesCopyAndWaitFromURL(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	shareName := fmt.Sprintf("share-%d", testhelpers.RandomInt())
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+	sharesClient, err := shares.NewWithBaseUri(fmt.Sprintf("https://%s.file.%s", accountName, *domainSuffix))
+	if err := client.PrepareWithSharedKeyAuth(sharesClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	input := shares.CreateInput{
+		QuotaInGB: 10,
+	}
+	_, err = sharesClient.Create(ctx, shareName, input)
+	if err != nil {
+		t.Fatalf("Error creating fileshare: %s", err)
+	}
+	defer sharesClient.Delete(ctx, shareName, shares.DeleteInput{DeleteSnapshots: false})
+
+	filesClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.file.%s", accountName, *domainSuffix))
+	if err := client.PrepareWithSharedKeyAuth(filesClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	copiedFileName := "ubuntu.iso"
+	copyInput := CopyInput{
+		CopySource: "http://releases.ubuntu.com/14.04/ubuntu-14.04.6-desktop-amd64.iso",
+	}
+
+	t.Logf("[DEBUG] Copy And Waiting..")
+	if _, err := filesClient.CopyAndWait(ctx, shareName, "", copiedFileName, copyInput); err != nil {
+		t.Fatalf("Error copy & waiting: %s", err)
+	}
+
+	t.Logf("[DEBUG] Asserting that the file's ready..")
+
+	props, err := filesClient.GetProperties(ctx, shareName, "", copiedFileName)
+	if err != nil {
+		t.Fatalf("Error retrieving file: %s", err)
+	}
+
+	if !strings.EqualFold(props.CopyStatus, "success") {
+		t.Fatalf("Expected the Copy Status to be `Success` but got %q", props.CopyStatus)
+	}
+}
+
+func TestFilesCopyAndWaitFromBlob(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	shareName := fmt.Sprintf("share-%d", testhelpers.RandomInt())
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+	sharesClient, err := shares.NewWithBaseUri(fmt.Sprintf("https://%s.file.%s", accountName, *domainSuffix))
+	if err := client.PrepareWithSharedKeyAuth(sharesClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	input := shares.CreateInput{
+		QuotaInGB: 10,
+	}
+	_, err = sharesClient.Create(ctx, shareName, input)
+	if err != nil {
+		t.Fatalf("Error creating fileshare: %s", err)
+	}
+	defer sharesClient.Delete(ctx, shareName, shares.DeleteInput{DeleteSnapshots: false})
+
+	baseUri := fmt.Sprintf("https://%s.file.%s", accountName, *domainSuffix)
+	filesClient, err := NewWithBaseUri(baseUri)
+	if err := client.PrepareWithSharedKeyAuth(filesClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	originalFileName := "ubuntu.iso"
+	copiedFileName := "ubuntu-copied.iso"
+	copyInput := CopyInput{
+		CopySource: "http://releases.ubuntu.com/14.04/ubuntu-14.04.6-desktop-amd64.iso",
+	}
+	t.Logf("[DEBUG] Copy And Waiting the original file..")
+	if _, err := filesClient.CopyAndWait(ctx, shareName, "", originalFileName, copyInput); err != nil {
+		t.Fatalf("Error copy & waiting: %s", err)
+	}
+
+	t.Logf("[DEBUG] Now copying that blob..")
+	duplicateInput := CopyInput{
+		CopySource: fmt.Sprintf("%s/%s/%s", baseUri, shareName, originalFileName),
+	}
+	if _, err := filesClient.CopyAndWait(ctx, shareName, "", copiedFileName, duplicateInput); err != nil {
+		t.Fatalf("Error copying duplicate: %s", err)
+	}
+
+	t.Logf("[DEBUG] Asserting that the file's ready..")
+	props, err := filesClient.GetProperties(ctx, shareName, "", copiedFileName)
+	if err != nil {
+		t.Fatalf("Error retrieving file: %s", err)
+	}
+
+	if !strings.EqualFold(props.CopyStatus, "success") {
+		t.Fatalf("Expected the Copy Status to be `Success` but got %q", props.CopyStatus)
+	}
+}

--- a/storage/2026-02-06/file/files/copy_wait_test.go
+++ b/storage/2026-02-06/file/files/copy_wait_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
-	"github.com/jackofallops/giovanni/storage/2020-08-04/file/shares"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/file/shares"
 	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
 )
 

--- a/storage/2026-02-06/file/files/create.go
+++ b/storage/2026-02-06/file/files/create.go
@@ -1,0 +1,166 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type CreateInput struct {
+	// This header specifies the maximum size for the file, up to 1 TiB.
+	ContentLength int64
+
+	// The MIME content type of the file
+	// If not specified, the default type is application/octet-stream.
+	ContentType *string
+
+	// Specifies which content encodings have been applied to the file.
+	// This value is returned to the client when the Get File operation is performed
+	// on the file resource and can be used to decode file content.
+	ContentEncoding *string
+
+	// Specifies the natural languages used by this resource.
+	ContentLanguage *string
+
+	// The File service stores this value but does not use or modify it.
+	CacheControl *string
+
+	// Sets the file's MD5 hash.
+	ContentMD5 *string
+
+	// Sets the file’s Content-Disposition header.
+	ContentDisposition *string
+
+	// The time at which this file was created at - if omitted, this'll be set to "now"
+	// This maps to the `x-ms-file-creation-time` field.
+	CreatedAt *time.Time
+
+	// The time at which this file was last modified - if omitted, this'll be set to "now"
+	// This maps to the `x-ms-file-last-write-time` field.
+	LastModified *time.Time
+
+	// MetaData is a mapping of key value pairs which should be assigned to this file
+	MetaData map[string]string
+}
+
+type CreateResponse struct {
+	HttpResponse *http.Response
+}
+
+// Create creates a new file or replaces a file.
+func (c Client) Create(ctx context.Context, shareName, path, fileName string, input CreateInput) (result CreateResponse, err error) {
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if fileName == "" {
+		err = fmt.Errorf("`fileName` cannot be an empty string")
+		return
+	}
+
+	if err = metadata.Validate(input.MetaData); err != nil {
+		err = fmt.Errorf("`input.MetaData` is not valid: %s", err)
+		return
+	}
+
+	if path != "" {
+		path = fmt.Sprintf("%s/", path)
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: CreateOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s%s", shareName, path, fileName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type CreateOptions struct {
+	input CreateInput
+}
+
+func (c CreateOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	var coalesceDate = func(input *time.Time, defaultVal string) string {
+		if input == nil {
+			return defaultVal
+		}
+
+		return input.Format(time.RFC1123)
+	}
+
+	if len(c.input.MetaData) > 0 {
+		headers.Merge(metadata.SetMetaDataHeaders(c.input.MetaData))
+	}
+
+	headers.Append("x-ms-content-length", strconv.Itoa(int(c.input.ContentLength)))
+	headers.Append("x-ms-type", "file")
+
+	headers.Append("x-ms-file-permission", "inherit") // TODO: expose this in future
+	headers.Append("x-ms-file-attributes", "None")    // TODO: expose this in future
+	headers.Append("x-ms-file-creation-time", coalesceDate(c.input.CreatedAt, "now"))
+	headers.Append("x-ms-file-last-write-time", coalesceDate(c.input.LastModified, "now"))
+
+	if c.input.ContentDisposition != nil {
+		headers.Append("x-ms-content-disposition", *c.input.ContentDisposition)
+	}
+
+	if c.input.ContentEncoding != nil {
+		headers.Append("x-ms-content-encoding", *c.input.ContentEncoding)
+	}
+
+	if c.input.ContentMD5 != nil {
+		headers.Append("x-ms-content-md5", *c.input.ContentMD5)
+	}
+
+	if c.input.ContentType != nil {
+		headers.Append("x-ms-content-type", *c.input.ContentType)
+	}
+
+	return headers
+}
+
+func (c CreateOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (c CreateOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/file/files/delete.go
+++ b/storage/2026-02-06/file/files/delete.go
@@ -1,0 +1,65 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+)
+
+type DeleteResponse struct {
+	HttpResponse *http.Response
+}
+
+// Delete immediately deletes the file from the File Share.
+func (c Client) Delete(ctx context.Context, shareName, path, fileName string) (result DeleteResponse, err error) {
+
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if fileName == "" {
+		err = fmt.Errorf("`fileName` cannot be an empty string")
+		return
+	}
+
+	if path != "" {
+		path = fmt.Sprintf("%s/", path)
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+		},
+		HttpMethod:    http.MethodDelete,
+		OptionsObject: nil,
+		Path:          fmt.Sprintf("%s/%s%s", shareName, path, fileName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}

--- a/storage/2026-02-06/file/files/lifecycle_test.go
+++ b/storage/2026-02-06/file/files/lifecycle_test.go
@@ -1,0 +1,169 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2020-08-04/file/shares"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+var _ StorageFile = Client{}
+
+func TestFilesLifeCycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	shareName := fmt.Sprintf("share-%d", testhelpers.RandomInt())
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+	sharesClient, err := shares.NewWithBaseUri(fmt.Sprintf("https://%s.file.%s", accountName, *domainSuffix))
+	if err := client.PrepareWithSharedKeyAuth(sharesClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	input := shares.CreateInput{
+		QuotaInGB: 1,
+	}
+	_, err = sharesClient.Create(ctx, shareName, input)
+	if err != nil {
+		t.Fatalf("Error creating fileshare: %s", err)
+	}
+
+	defer sharesClient.Delete(ctx, shareName, shares.DeleteInput{DeleteSnapshots: false})
+
+	filesClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.file.%s", accountName, *domainSuffix))
+	if err := client.PrepareWithSharedKeyAuth(filesClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	fileName := "bled5.png"
+	contentEncoding := "application/vnd+panda"
+
+	t.Logf("[DEBUG] Creating Top Level File..")
+	createInput := CreateInput{
+		ContentLength:   1024,
+		ContentEncoding: &contentEncoding,
+	}
+	if _, err := filesClient.Create(ctx, shareName, "", fileName, createInput); err != nil {
+		t.Fatalf("Error creating Top-Level File: %s", err)
+	}
+
+	t.Logf("[DEBUG] Retrieving Properties for the Top-Level File..")
+	file, err := filesClient.GetProperties(ctx, shareName, "", fileName)
+	if err != nil {
+		t.Fatalf("Error retrieving Top-Level File: %s", err)
+	}
+
+	if *file.ContentLength != 1024 {
+		t.Fatalf("Expected the Content-Length to be 1024 but got %d", *file.ContentLength)
+	}
+
+	if file.ContentEncoding != contentEncoding {
+		t.Fatalf("Expected the Content-Encoding to be %q but got %q", contentEncoding, file.ContentEncoding)
+	}
+
+	updatedSize := int64(2048)
+	updatedEncoding := "application/vnd+pandas2"
+	updatedInput := SetPropertiesInput{
+		ContentEncoding: &updatedEncoding,
+		ContentLength:   updatedSize,
+		MetaData: map[string]string{
+			"bingo": "bango",
+		},
+	}
+	t.Logf("[DEBUG] Setting Properties for the Top-Level File..")
+	if _, err := filesClient.SetProperties(ctx, shareName, "", fileName, updatedInput); err != nil {
+		t.Fatalf("Error setting properties: %s", err)
+	}
+
+	t.Logf("[DEBUG] Re-retrieving Properties for the Top-Level File..")
+	file, err = filesClient.GetProperties(ctx, shareName, "", fileName)
+	if err != nil {
+		t.Fatalf("Error retrieving Top-Level File: %s", err)
+	}
+
+	if *file.ContentLength != 2048 {
+		t.Fatalf("Expected the Content-Length to be 1024 but got %d", *file.ContentLength)
+	}
+
+	if file.ContentEncoding != updatedEncoding {
+		t.Fatalf("Expected the Content-Encoding to be %q but got %q", updatedEncoding, file.ContentEncoding)
+	}
+
+	if len(file.MetaData) != 1 {
+		t.Fatalf("Expected 1 item but got %d", len(file.MetaData))
+	}
+	if file.MetaData["bingo"] != "bango" {
+		t.Fatalf("Expected `bingo` to be `bango` but got %q", file.MetaData["bingo"])
+	}
+
+	t.Logf("[DEBUG] Setting MetaData..")
+	metaData := map[string]string{
+		"hello": "there",
+	}
+	if _, err := filesClient.SetMetaData(ctx, shareName, "", fileName, SetMetaDataInput{MetaData: metaData}); err != nil {
+		t.Fatalf("Error setting MetaData: %s", err)
+	}
+
+	t.Logf("[DEBUG] Retrieving MetaData..")
+	retrievedMetaData, err := filesClient.GetMetaData(ctx, shareName, "", fileName)
+	if err != nil {
+		t.Fatalf("Error retrieving MetaData: %s", err)
+	}
+	if len(retrievedMetaData.MetaData) != 1 {
+		t.Fatalf("Expected 1 item but got %d", len(retrievedMetaData.MetaData))
+	}
+	if retrievedMetaData.MetaData["hello"] != "there" {
+		t.Fatalf("Expected `hello` to be `there` but got %q", retrievedMetaData.MetaData["hello"])
+	}
+
+	t.Logf("[DEBUG] Re-Setting MetaData..")
+	metaData = map[string]string{
+		"hello":  "there",
+		"second": "thing",
+	}
+	if _, err := filesClient.SetMetaData(ctx, shareName, "", fileName, SetMetaDataInput{MetaData: metaData}); err != nil {
+		t.Fatalf("Error setting MetaData: %s", err)
+	}
+
+	t.Logf("[DEBUG] Re-Retrieving MetaData..")
+	retrievedMetaData, err = filesClient.GetMetaData(ctx, shareName, "", fileName)
+	if err != nil {
+		t.Fatalf("Error retrieving MetaData: %s", err)
+	}
+	if len(retrievedMetaData.MetaData) != 2 {
+		t.Fatalf("Expected 2 items but got %d", len(retrievedMetaData.MetaData))
+	}
+	if retrievedMetaData.MetaData["hello"] != "there" {
+		t.Fatalf("Expected `hello` to be `there` but got %q", retrievedMetaData.MetaData["hello"])
+	}
+	if retrievedMetaData.MetaData["second"] != "thing" {
+		t.Fatalf("Expected `second` to be `thing` but got %q", retrievedMetaData.MetaData["second"])
+	}
+
+	t.Logf("[DEBUG] Deleting Top Level File..")
+	if _, err := filesClient.Delete(ctx, shareName, "", fileName); err != nil {
+		t.Fatalf("Error deleting Top-Level File: %s", err)
+	}
+}

--- a/storage/2026-02-06/file/files/lifecycle_test.go
+++ b/storage/2026-02-06/file/files/lifecycle_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
-	"github.com/jackofallops/giovanni/storage/2020-08-04/file/shares"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/file/shares"
 	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
 )
 

--- a/storage/2026-02-06/file/files/metadata_get.go
+++ b/storage/2026-02-06/file/files/metadata_get.go
@@ -1,0 +1,90 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type GetMetaDataResponse struct {
+	HttpResponse *http.Response
+
+	MetaData map[string]string
+}
+
+// GetMetaData returns the MetaData for the specified File.
+func (c Client) GetMetaData(ctx context.Context, shareName, path, fileName string) (result GetMetaDataResponse, err error) {
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if fileName == "" {
+		err = fmt.Errorf("`fileName` cannot be an empty string")
+		return
+	}
+
+	if path != "" {
+		path = fmt.Sprintf("%s/", path)
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: GetMetadataOptions{},
+		Path:          fmt.Sprintf("/%s/%s%s", shareName, path, fileName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.MetaData = metadata.ParseFromHeaders(resp.Header)
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type GetMetadataOptions struct{}
+
+func (m GetMetadataOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (m GetMetadataOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (m GetMetadataOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "metadata")
+	return out
+}

--- a/storage/2026-02-06/file/files/metadata_set.go
+++ b/storage/2026-02-06/file/files/metadata_set.go
@@ -1,0 +1,100 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type SetMetaDataResponse struct {
+	HttpResponse *http.Response
+}
+
+type SetMetaDataInput struct {
+	MetaData map[string]string
+}
+
+// SetMetaData updates the specified File to have the specified MetaData.
+func (c Client) SetMetaData(ctx context.Context, shareName, path, fileName string, input SetMetaDataInput) (result SetMetaDataResponse, err error) {
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if fileName == "" {
+		err = fmt.Errorf("`fileName` cannot be an empty string")
+		return
+	}
+
+	if err = metadata.Validate(input.MetaData); err != nil {
+		err = fmt.Errorf("`input.MetaData` is not valid: %s", err)
+		return
+	}
+
+	if path != "" {
+		path = fmt.Sprintf("%s/", path)
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: SetMetaDataOptions{
+			metaData: input.MetaData,
+		},
+		Path: fmt.Sprintf("%s/%s%s", shareName, path, fileName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type SetMetaDataOptions struct {
+	metaData map[string]string
+}
+
+func (s SetMetaDataOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	if len(s.metaData) > 0 {
+		headers.Merge(metadata.SetMetaDataHeaders(s.metaData))
+	}
+	return headers
+}
+
+func (s SetMetaDataOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (s SetMetaDataOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "metadata")
+	return out
+}

--- a/storage/2026-02-06/file/files/properties_get.go
+++ b/storage/2026-02-06/file/files/properties_get.go
@@ -1,0 +1,114 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type GetResponse struct {
+	HttpResponse *http.Response
+
+	CacheControl          string
+	ContentDisposition    string
+	ContentEncoding       string
+	ContentLanguage       string
+	ContentLength         *int64
+	ContentMD5            string
+	ContentType           string
+	CopyID                string
+	CopyStatus            string
+	CopySource            string
+	CopyProgress          string
+	CopyStatusDescription string
+	CopyCompletionTime    string
+	Encrypted             bool
+
+	MetaData map[string]string
+}
+
+// GetProperties returns the Properties for the specified file
+func (c Client) GetProperties(ctx context.Context, shareName, path, fileName string) (result GetResponse, err error) {
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if fileName == "" {
+		err = fmt.Errorf("`fileName` cannot be an empty string")
+		return
+	}
+
+	if path != "" {
+		path = fmt.Sprintf("%s/", path)
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodHead,
+		OptionsObject: nil,
+		Path:          fmt.Sprintf("%s/%s%s", shareName, path, fileName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.CacheControl = resp.Header.Get("Cache-Control")
+				result.ContentDisposition = resp.Header.Get("Content-Disposition")
+				result.ContentEncoding = resp.Header.Get("Content-Encoding")
+				result.ContentLanguage = resp.Header.Get("Content-Language")
+				result.ContentMD5 = resp.Header.Get("Content-MD5")
+				result.ContentType = resp.Header.Get("Content-Type")
+				result.CopyCompletionTime = resp.Header.Get("x-ms-copy-completion-time")
+				result.CopyID = resp.Header.Get("x-ms-copy-id")
+				result.CopyProgress = resp.Header.Get("x-ms-copy-progress")
+				result.CopySource = resp.Header.Get("x-ms-copy-source")
+				result.CopyStatus = resp.Header.Get("x-ms-copy-status")
+				result.CopyStatusDescription = resp.Header.Get("x-ms-copy-status-description")
+				result.Encrypted = strings.EqualFold(resp.Header.Get("x-ms-server-encrypted"), "true")
+				result.MetaData = metadata.ParseFromHeaders(resp.Header)
+
+				contentLengthRaw := resp.Header.Get("Content-Length")
+				if contentLengthRaw != "" {
+					var contentLength int
+					contentLength, err = strconv.Atoi(contentLengthRaw)
+					if err != nil {
+						err = fmt.Errorf("parsing `Content-Length` header value %q: %s", contentLengthRaw, err)
+						return
+					}
+					contentLengthI64 := int64(contentLength)
+					result.ContentLength = &contentLengthI64
+				}
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}

--- a/storage/2026-02-06/file/files/properties_set.go
+++ b/storage/2026-02-06/file/files/properties_set.go
@@ -1,0 +1,180 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type SetPropertiesInput struct {
+	// Resizes a file to the specified size.
+	// If the specified byte value is less than the current size of the file,
+	// then all ranges above the specified byte value are cleared.
+	ContentLength int64
+
+	// Modifies the cache control string for the file.
+	// If this property is not specified on the request, then the property will be cleared for the file.
+	// Subsequent calls to Get File Properties will not return this property,
+	// unless it is explicitly set on the file again.
+	ContentControl *string
+
+	// Sets the file’s Content-Disposition header.
+	// If this property is not specified on the request, then the property will be cleared for the file.
+	// Subsequent calls to Get File Properties will not return this property,
+	// unless it is explicitly set on the file again.
+	ContentDisposition *string
+
+	// Sets the file's content encoding.
+	// If this property is not specified on the request, then the property will be cleared for the file.
+	// Subsequent calls to Get File Properties will not return this property,
+	// unless it is explicitly set on the file again.
+	ContentEncoding *string
+
+	// Sets the file's content language.
+	// If this property is not specified on the request, then the property will be cleared for the file.
+	// Subsequent calls to Get File Properties will not return this property,
+	// unless it is explicitly set on the file again.
+	ContentLanguage *string
+
+	// Sets the file's MD5 hash.
+	// If this property is not specified on the request, then the property will be cleared for the file.
+	// Subsequent calls to Get File Properties will not return this property,
+	// unless it is explicitly set on the file again.
+	ContentMD5 *string
+
+	// Sets the file's content type.
+	// If this property is not specified on the request, then the property will be cleared for the file.
+	// Subsequent calls to Get File Properties will not return this property,
+	// unless it is explicitly set on the file again.
+	ContentType *string
+
+	// The time at which this file was created at - if omitted, this'll be set to "now"
+	// This maps to the `x-ms-file-creation-time` field.
+	CreatedAt *time.Time
+
+	// The time at which this file was last modified - if omitted, this'll be set to "now"
+	// This maps to the `x-ms-file-last-write-time` field.
+	LastModified *time.Time
+
+	// MetaData is a mapping of key value pairs which should be assigned to this file
+	MetaData map[string]string
+}
+
+type SetPropertiesResponse struct {
+	HttpResponse *http.Response
+}
+
+// SetProperties sets the specified properties on the specified File
+func (c Client) SetProperties(ctx context.Context, shareName, path, fileName string, input SetPropertiesInput) (result SetPropertiesResponse, err error) {
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if fileName == "" {
+		err = fmt.Errorf("`fileName` cannot be an empty string")
+		return
+	}
+
+	if path != "" {
+		path = fmt.Sprintf("%s/", path)
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: SetPropertiesOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("%s/%s%s", shareName, path, fileName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type SetPropertiesOptions struct {
+	input SetPropertiesInput
+}
+
+func (s SetPropertiesOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	var coalesceDate = func(input *time.Time, defaultVal string) string {
+		if input == nil {
+			return defaultVal
+		}
+
+		return input.Format(time.RFC1123)
+	}
+
+	headers.Append("x-ms-type", "file")
+
+	headers.Append("x-ms-content-length", strconv.Itoa(int(s.input.ContentLength)))
+	headers.Append("x-ms-file-permission", "inherit") // TODO: expose this in future
+	headers.Append("x-ms-file-attributes", "None")    // TODO: expose this in future
+	headers.Append("x-ms-file-creation-time", coalesceDate(s.input.CreatedAt, "now"))
+	headers.Append("x-ms-file-last-write-time", coalesceDate(s.input.LastModified, "now"))
+
+	if s.input.ContentControl != nil {
+		headers.Append("x-ms-cache-control", *s.input.ContentControl)
+	}
+	if s.input.ContentDisposition != nil {
+		headers.Append("x-ms-content-disposition", *s.input.ContentDisposition)
+	}
+	if s.input.ContentEncoding != nil {
+		headers.Append("x-ms-content-encoding", *s.input.ContentEncoding)
+	}
+	if s.input.ContentLanguage != nil {
+		headers.Append("x-ms-content-language", *s.input.ContentLanguage)
+	}
+	if s.input.ContentMD5 != nil {
+		headers.Append("x-ms-content-md5", *s.input.ContentMD5)
+	}
+	if s.input.ContentType != nil {
+		headers.Append("x-ms-content-type", *s.input.ContentType)
+	}
+
+	if len(s.input.MetaData) > 0 {
+		headers.Merge(metadata.SetMetaDataHeaders(s.input.MetaData))
+	}
+
+	return headers
+}
+
+func (s SetPropertiesOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (s SetPropertiesOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/file/files/range_clear.go
+++ b/storage/2026-02-06/file/files/range_clear.go
@@ -1,0 +1,104 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type ClearByteRangeInput struct {
+	StartBytes int64
+	EndBytes   int64
+}
+
+type ClearByteRangeResponse struct {
+	HttpResponse *http.Response
+}
+
+// ClearByteRange clears the specified Byte Range from within the specified File
+func (c Client) ClearByteRange(ctx context.Context, shareName, path, fileName string, input ClearByteRangeInput) (result ClearByteRangeResponse, err error) {
+
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if fileName == "" {
+		err = fmt.Errorf("`fileName` cannot be an empty string")
+		return
+	}
+
+	if input.StartBytes < 0 {
+		err = fmt.Errorf("`input.StartBytes` must be greater or equal to 0")
+		return
+	}
+
+	if input.EndBytes <= 0 {
+		err = fmt.Errorf("`input.EndBytes` must be greater than 0")
+		return
+	}
+
+	if path != "" {
+		path = fmt.Sprintf("%s/", path)
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: ClearByteRangeOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s%s", shareName, path, fileName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type ClearByteRangeOptions struct {
+	input ClearByteRangeInput
+}
+
+func (c ClearByteRangeOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("x-ms-write", "clear")
+	headers.Append("x-ms-range", fmt.Sprintf("bytes=%d-%d", c.input.StartBytes, c.input.EndBytes))
+	return headers
+}
+
+func (c ClearByteRangeOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (c ClearByteRangeOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "range")
+	return out
+}

--- a/storage/2026-02-06/file/files/range_get.go
+++ b/storage/2026-02-06/file/files/range_get.go
@@ -1,0 +1,129 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type GetByteRangeInput struct {
+	StartBytes int64
+	EndBytes   int64
+}
+
+type GetByteRangeResponse struct {
+	HttpResponse *http.Response
+	Contents     *[]byte
+}
+
+// GetByteRange returns the specified Byte Range from the specified File.
+func (c Client) GetByteRange(ctx context.Context, shareName, path, fileName string, input GetByteRangeInput) (result GetByteRangeResponse, err error) {
+
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if fileName == "" {
+		err = fmt.Errorf("`fileName` cannot be an empty string")
+		return
+	}
+
+	if input.StartBytes < 0 {
+		err = fmt.Errorf("`input.StartBytes` must be greater or equal to 0")
+		return
+	}
+
+	if input.EndBytes <= 0 {
+		err = fmt.Errorf("`input.EndBytes` must be greater than 0")
+		return
+	}
+
+	expectedBytes := input.EndBytes - input.StartBytes
+	if expectedBytes < (4 * 1024) {
+		err = fmt.Errorf("requested Byte Range must be at least 4KB")
+		return
+	}
+	if expectedBytes > (4 * 1024 * 1024) {
+		err = fmt.Errorf("requested Byte Range must be at most 4MB")
+		return
+	}
+
+	if path != "" {
+		path = fmt.Sprintf("%s/", path)
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+			http.StatusPartialContent,
+		},
+		HttpMethod: http.MethodGet,
+		OptionsObject: GetByteRangeOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/%s%s", shareName, path, fileName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			result.Contents = &[]byte{}
+			if resp.Body != nil {
+				respBody, err := io.ReadAll(resp.Body)
+				defer resp.Body.Close()
+				if err != nil {
+					return result, fmt.Errorf("could not parse response body")
+				}
+
+				if respBody != nil {
+					result.Contents = pointer.To(respBody)
+				}
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type GetByteRangeOptions struct {
+	input GetByteRangeInput
+}
+
+func (g GetByteRangeOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("x-ms-range", fmt.Sprintf("bytes=%d-%d", g.input.StartBytes, g.input.EndBytes-1))
+	return headers
+}
+
+func (g GetByteRangeOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (g GetByteRangeOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/file/files/range_get_file.go
+++ b/storage/2026-02-06/file/files/range_get_file.go
@@ -1,0 +1,140 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math"
+	"net/http"
+	"runtime"
+	"sync"
+)
+
+type GetFileInput struct {
+	Parallelism int
+}
+
+type GetFileResponse struct {
+	HttpResponse *http.Response
+	OutputBytes  *[]byte
+}
+
+// GetFile is a helper method to download a file by chunking it automatically
+func (c Client) GetFile(ctx context.Context, shareName, path, fileName string, input GetFileInput) (result GetFileResponse, err error) {
+
+	// first look up the file and check out how many bytes it is
+	file, e := c.GetProperties(ctx, shareName, path, fileName)
+	if err != nil {
+		result.HttpResponse = file.HttpResponse
+		err = e
+		return
+	}
+
+	if file.ContentLength == nil {
+		err = fmt.Errorf("Content-Length was nil")
+		return
+	}
+
+	result.HttpResponse = file.HttpResponse
+	length := *file.ContentLength
+	chunkSize := int64(4 * 1024 * 1024) // 4MB
+
+	if chunkSize > length {
+		chunkSize = length
+	}
+
+	// then split that up into chunks and retrieve it into the 'results' set
+	chunks := int(math.Ceil(float64(length) / float64(chunkSize)))
+	workerCount := input.Parallelism * runtime.NumCPU()
+	if workerCount > chunks {
+		workerCount = chunks
+	}
+
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(workerCount)
+
+	results := make([]*downloadFileChunkResult, chunks)
+	errors := make(chan error, chunkSize)
+
+	for i := 0; i < chunks; i++ {
+		go func(i int) {
+			log.Printf("[DEBUG] Downloading Chunk %d of %d", i+1, chunks)
+
+			dfci := downloadFileChunkInput{
+				thisChunk: i,
+				chunkSize: chunkSize,
+				fileSize:  length,
+			}
+
+			result, err := c.downloadFileChunk(ctx, shareName, path, fileName, dfci)
+			if err != nil {
+				errors <- err
+				waitGroup.Done()
+				return
+			}
+
+			// if there's no error, we should have bytes, so this is safe
+			results[i] = result
+
+			waitGroup.Done()
+		}(i)
+	}
+	waitGroup.Wait()
+
+	// TODO: we should switch to hashicorp/multi-error here
+	if len(errors) > 0 {
+		err = fmt.Errorf("Error downloading file: %s", <-errors)
+		return
+	}
+
+	// then finally put it all together, in order and return it
+	output := make([]byte, length)
+	for _, v := range results {
+		copy(output[v.startBytes:v.endBytes], *v.bytes)
+	}
+
+	if result.OutputBytes == nil {
+		result.OutputBytes = &[]byte{}
+	}
+	*result.OutputBytes = output
+	return
+}
+
+type downloadFileChunkInput struct {
+	thisChunk int
+	chunkSize int64
+	fileSize  int64
+}
+
+type downloadFileChunkResult struct {
+	startBytes int64
+	endBytes   int64
+	bytes      *[]byte
+}
+
+func (c Client) downloadFileChunk(ctx context.Context, shareName, path, fileName string, input downloadFileChunkInput) (*downloadFileChunkResult, error) {
+	startBytes := input.chunkSize * int64(input.thisChunk)
+	endBytes := startBytes + input.chunkSize
+
+	// the last chunk may exceed the size of the file
+	remaining := input.fileSize - startBytes
+	if input.chunkSize > remaining {
+		endBytes = startBytes + remaining
+	}
+
+	getInput := GetByteRangeInput{
+		StartBytes: startBytes,
+		EndBytes:   endBytes,
+	}
+	result, err := c.GetByteRange(ctx, shareName, path, fileName, getInput)
+	if err != nil {
+		return nil, fmt.Errorf("error putting bytes: %s", err)
+	}
+
+	output := downloadFileChunkResult{
+		startBytes: startBytes,
+		endBytes:   endBytes,
+		bytes:      result.Contents,
+	}
+	return &output, nil
+}

--- a/storage/2026-02-06/file/files/range_get_file_test.go
+++ b/storage/2026-02-06/file/files/range_get_file_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
-	"github.com/jackofallops/giovanni/storage/2020-08-04/file/shares"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/file/shares"
 	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
 )
 

--- a/storage/2026-02-06/file/files/range_get_file_test.go
+++ b/storage/2026-02-06/file/files/range_get_file_test.go
@@ -1,0 +1,120 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2020-08-04/file/shares"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+func TestGetSmallFile(t *testing.T) {
+	// the purpose of this test is to verify that the small, single-chunked file gets downloaded correctly
+	testGetFile(t, "small-file.png", "image/png")
+}
+
+func TestGetLargeFile(t *testing.T) {
+	// the purpose of this test is to verify that the large, multi-chunked file gets downloaded correctly
+	testGetFile(t, "blank-large-file.dmg", "application/x-apple-diskimage")
+}
+
+func testGetFile(t *testing.T, fileName string, contentType string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	shareName := fmt.Sprintf("share-%d", testhelpers.RandomInt())
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+	sharesClient, err := shares.NewWithBaseUri(fmt.Sprintf("https://%s.file.%s", accountName, *domainSuffix))
+	if err := client.PrepareWithSharedKeyAuth(sharesClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	input := shares.CreateInput{
+		QuotaInGB: 10,
+	}
+	_, err = sharesClient.Create(ctx, shareName, input)
+	if err != nil {
+		t.Fatalf("Error creating fileshare: %s", err)
+	}
+	defer sharesClient.Delete(ctx, shareName, shares.DeleteInput{DeleteSnapshots: false})
+
+	filesClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.file.%s", accountName, *domainSuffix))
+	if err := client.PrepareWithSharedKeyAuth(filesClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	// store files outside of this directory, since they're reused
+	file, err := os.Open("../../../testdata/" + fileName)
+	if err != nil {
+		t.Fatalf("Error opening: %s", err)
+	}
+
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatalf("Error 'stat'-ing: %s", err)
+	}
+
+	t.Logf("[DEBUG] Creating Top Level File..")
+	createFileInput := CreateInput{
+		ContentLength: info.Size(),
+		ContentType:   &contentType,
+	}
+	if _, err := filesClient.Create(ctx, shareName, "", fileName, createFileInput); err != nil {
+		t.Fatalf("Error creating Top-Level File: %s", err)
+	}
+
+	t.Logf("[DEBUG] Uploading File..")
+	if err := filesClient.PutFile(ctx, shareName, "", fileName, file, 4); err != nil {
+		t.Fatalf("Error uploading File: %s", err)
+	}
+
+	t.Logf("[DEBUG] Downloading file..")
+	resp, err := filesClient.GetFile(ctx, shareName, "", fileName, GetFileInput{Parallelism: 4})
+	if err != nil {
+		t.Fatalf("Error downloading file: %s", err)
+	}
+
+	t.Logf("[DEBUG] Asserting the files are the same size..")
+	expectedBytes := make([]byte, info.Size())
+	file.Read(expectedBytes)
+	outputBytes := *resp.OutputBytes
+	if len(expectedBytes) != len(*resp.OutputBytes) {
+		t.Fatalf("Expected %d bytes but got %d", len(expectedBytes), len(outputBytes))
+	}
+
+	t.Logf("[DEBUG] Asserting the files are the same content-wise..")
+	// overkill, but it's this or shasum-ing
+	for i := int64(0); i < info.Size(); i++ {
+		if expectedBytes[i] != outputBytes[i] {
+			t.Fatalf("Expected byte %d to be %q but got %q", i, expectedBytes[i], outputBytes[i])
+		}
+	}
+
+	t.Logf("[DEBUG] Deleting Top Level File..")
+	if _, err := filesClient.Delete(ctx, shareName, "", fileName); err != nil {
+		t.Fatalf("Error deleting Top-Level File: %s", err)
+	}
+
+}

--- a/storage/2026-02-06/file/files/range_put.go
+++ b/storage/2026-02-06/file/files/range_put.go
@@ -1,0 +1,124 @@
+package files
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type PutByteRangeInput struct {
+	StartBytes int64
+	EndBytes   int64
+
+	// Content is the File Contents for the specified range
+	// which can be at most 4MB
+	Content []byte
+}
+
+type PutRangeResponse struct {
+	HttpResponse *http.Response
+}
+
+// PutByteRange puts the specified Byte Range in the specified File.
+func (c Client) PutByteRange(ctx context.Context, shareName, path, fileName string, input PutByteRangeInput) (result PutRangeResponse, err error) {
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if fileName == "" {
+		err = fmt.Errorf("`fileName` cannot be an empty string")
+		return
+	}
+
+	if input.StartBytes < 0 {
+		err = fmt.Errorf("`input.StartBytes` must be greater or equal to 0")
+		return
+	}
+	if input.EndBytes <= 0 {
+		err = fmt.Errorf("`input.EndBytes` must be greater than 0")
+		return
+	}
+
+	expectedBytes := input.EndBytes - input.StartBytes
+	actualBytes := len(input.Content)
+	if expectedBytes != int64(actualBytes) {
+		err = fmt.Errorf(fmt.Sprintf("The specified byte-range (%d) didn't match the content size (%d).", expectedBytes, actualBytes))
+		return
+	}
+
+	if expectedBytes > (4 * 1024 * 1024) {
+		err = fmt.Errorf("specified Byte Range must be at most 4MB")
+		return
+	}
+
+	if path != "" {
+		path = fmt.Sprintf("%s/", path)
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: PutRangeOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("%s/%s%s", shareName, path, fileName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	req.Body = io.NopCloser(bytes.NewReader(input.Content))
+	req.ContentLength = int64(len(input.Content))
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type PutRangeOptions struct {
+	input PutByteRangeInput
+}
+
+func (p PutRangeOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("x-ms-write", "update")
+	headers.Append("x-ms-range", fmt.Sprintf("bytes=%d-%d", p.input.StartBytes, p.input.EndBytes-1))
+	headers.Append("Content-Length", strconv.Itoa(len(p.input.Content)))
+	return headers
+}
+
+func (p PutRangeOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (p PutRangeOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "range")
+	return out
+}

--- a/storage/2026-02-06/file/files/range_put_file.go
+++ b/storage/2026-02-06/file/files/range_put_file.go
@@ -1,0 +1,112 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"os"
+	"sync"
+)
+
+// PutFile is a helper method which takes a file, and automatically chunks it up, rather than having to do this yourself
+func (c Client) PutFile(ctx context.Context, shareName, path, fileName string, file *os.File, parallelism int) error {
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("error loading file info: %s", err)
+	}
+	if fileInfo.Size() == 0 {
+		return fmt.Errorf("file is empty which is not supported")
+	}
+
+	fileSize := fileInfo.Size()
+	chunkSize := 4 * 1024 * 1024 // 4MB
+	if chunkSize > int(fileSize) {
+		chunkSize = int(fileSize)
+	}
+	chunks := int(math.Ceil(float64(fileSize) / float64(chunkSize*1.0)))
+
+	workerCount := parallelism
+	if workerCount > chunks {
+		workerCount = chunks
+	}
+
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(workerCount)
+
+	jobs := make(chan int, workerCount)
+	errors := make(chan error, chunkSize)
+
+	for i := 0; i < workerCount; i++ {
+		go func() {
+			for i := range jobs {
+				log.Printf("[DEBUG] Chunk %d of %d", i+1, chunks)
+
+				uci := uploadChunkInput{
+					thisChunk: i,
+					chunkSize: chunkSize,
+					fileSize:  fileSize,
+				}
+
+				_, err := c.uploadChunk(ctx, shareName, path, fileName, uci, file)
+				if err != nil {
+					errors <- err
+				}
+			}
+			waitGroup.Done()
+		}()
+	}
+
+	for i := 0; i < chunks; i++ {
+		jobs <- i
+	}
+	close(jobs)
+	waitGroup.Wait()
+
+	// TODO: we should switch to hashicorp/multi-error here
+	if len(errors) > 0 {
+		return fmt.Errorf("uploading file: %s", <-errors)
+	}
+
+	return nil
+}
+
+type uploadChunkInput struct {
+	thisChunk int
+	chunkSize int
+	fileSize  int64
+}
+
+func (c Client) uploadChunk(ctx context.Context, shareName, path, fileName string, input uploadChunkInput, file *os.File) (result PutRangeResponse, err error) {
+	startBytes := int64(input.chunkSize * input.thisChunk)
+	endBytes := startBytes + int64(input.chunkSize)
+
+	// the last size may exceed the size of the file
+	remaining := input.fileSize - startBytes
+	if int64(input.chunkSize) > remaining {
+		endBytes = startBytes + remaining
+	}
+
+	bytesToRead := int(endBytes) - int(startBytes)
+	bytes := make([]byte, bytesToRead)
+
+	_, err = file.ReadAt(bytes, startBytes)
+	if err != nil {
+		if err != io.EOF {
+			return result, fmt.Errorf("reading bytes: %s", err)
+		}
+	}
+
+	putBytesInput := PutByteRangeInput{
+		StartBytes: startBytes,
+		EndBytes:   endBytes,
+		Content:    bytes,
+	}
+	result, err = c.PutByteRange(ctx, shareName, path, fileName, putBytesInput)
+	if err != nil {
+		return result, fmt.Errorf("putting bytes: %s", err)
+	}
+
+	return
+}

--- a/storage/2026-02-06/file/files/range_put_file_test.go
+++ b/storage/2026-02-06/file/files/range_put_file_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
-	"github.com/jackofallops/giovanni/storage/2020-08-04/file/shares"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/file/shares"
 	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
 )
 

--- a/storage/2026-02-06/file/files/range_put_file_test.go
+++ b/storage/2026-02-06/file/files/range_put_file_test.go
@@ -1,0 +1,102 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2020-08-04/file/shares"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+func TestPutSmallFile(t *testing.T) {
+	// the purpose of this test is to ensure that a small file (< 4MB) is a single chunk
+	testPutFile(t, "small-file.png", "image/png")
+}
+
+func TestPutLargeFile(t *testing.T) {
+	// the purpose of this test is to ensure that large files (> 4MB) are chunked
+	testPutFile(t, "blank-large-file.dmg", "application/x-apple-diskimage")
+}
+
+func TestPutVerySmallFile(t *testing.T) {
+	// the purpose of this test is to ensure that a very small file (< 4KB) is a single chunk
+	testPutFile(t, "very-small.json", "application/json")
+}
+
+func testPutFile(t *testing.T, fileName string, contentType string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	shareName := fmt.Sprintf("share-%d", testhelpers.RandomInt())
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+	sharesClient, err := shares.NewWithBaseUri(fmt.Sprintf("https://%s.file.%s", accountName, *domainSuffix))
+	if err := client.PrepareWithSharedKeyAuth(sharesClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	input := shares.CreateInput{
+		QuotaInGB: 10,
+	}
+	_, err = sharesClient.Create(ctx, shareName, input)
+	if err != nil {
+		t.Fatalf("Error creating fileshare: %s", err)
+	}
+	defer sharesClient.Delete(ctx, shareName, shares.DeleteInput{DeleteSnapshots: false})
+
+	filesClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.file.%s", accountName, *domainSuffix))
+	if err := client.PrepareWithSharedKeyAuth(filesClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	// store files outside of this directory, since they're reused
+	file, err := os.Open("../../../testdata/" + fileName)
+	if err != nil {
+		t.Fatalf("Error opening: %s", err)
+	}
+
+	info, err := file.Stat()
+	if err != nil {
+		t.Fatalf("Error 'stat'-ing: %s", err)
+	}
+
+	t.Logf("[DEBUG] Creating Top Level File..")
+	createFileInput := CreateInput{
+		ContentLength: info.Size(),
+		ContentType:   &contentType,
+	}
+	if _, err := filesClient.Create(ctx, shareName, "", fileName, createFileInput); err != nil {
+		t.Fatalf("Error creating Top-Level File: %s", err)
+	}
+
+	t.Logf("[DEBUG] Uploading File..")
+	if err := filesClient.PutFile(ctx, shareName, "", fileName, file, 4); err != nil {
+		t.Fatalf("Error uploading File: %s", err)
+	}
+
+	t.Logf("[DEBUG] Deleting Top Level File..")
+	if _, err := filesClient.Delete(ctx, shareName, "", fileName); err != nil {
+		t.Fatalf("Error deleting Top-Level File: %s", err)
+	}
+}

--- a/storage/2026-02-06/file/files/ranges_list.go
+++ b/storage/2026-02-06/file/files/ranges_list.go
@@ -1,0 +1,101 @@
+package files
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type ListRangesResponse struct {
+	HttpResponse *http.Response
+
+	Ranges []Range `xml:"Range"`
+}
+
+type Range struct {
+	Start string `xml:"Start"`
+	End   string `xml:"End"`
+}
+
+// ListRanges returns the list of valid ranges for the specified File.
+func (c Client) ListRanges(ctx context.Context, shareName, path, fileName string) (result ListRangesResponse, err error) {
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if path == "" {
+		err = fmt.Errorf("`path` cannot be an empty string")
+		return
+	}
+
+	if fileName == "" {
+		err = fmt.Errorf("`fileName` cannot be an empty string")
+		return
+	}
+
+	if path != "" {
+		path = fmt.Sprintf("%s/", path)
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: ListRangeOptions{},
+		Path:          fmt.Sprintf("/%s/%s%s", shareName, path, fileName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			err = resp.Unmarshal(&result)
+			if err != nil {
+				err = fmt.Errorf("unmarshalling response: %+v", err)
+				return
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type ListRangeOptions struct{}
+
+func (l ListRangeOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (l ListRangeOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (l ListRangeOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "rangelist")
+	return out
+}

--- a/storage/2026-02-06/file/files/resource_id.go
+++ b/storage/2026-02-06/file/files/resource_id.go
@@ -1,0 +1,91 @@
+package files
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+// TODO: update this to implement `resourceids.ResourceId` once
+// https://github.com/hashicorp/go-azure-helpers/issues/187 is fixed
+var _ resourceids.Id = FileId{}
+
+type FileId struct {
+	// AccountId specifies the ID of the Storage Account where this File exists.
+	AccountId accounts.AccountId
+
+	// ShareName specifies the name of the File Share containing this File.
+	ShareName string
+
+	// DirectoryPath specifies the path representing the Directory where this File exists.
+	DirectoryPath string
+
+	// FileName specifies the name of the File.
+	FileName string
+}
+
+func NewFileID(accountId accounts.AccountId, shareName, directoryPath, fileName string) FileId {
+	return FileId{
+		AccountId:     accountId,
+		ShareName:     shareName,
+		DirectoryPath: directoryPath,
+		FileName:      fileName,
+	}
+}
+
+func (b FileId) ID() string {
+	path := ""
+	if b.DirectoryPath != "" {
+		path = fmt.Sprintf("%s/", b.DirectoryPath)
+	}
+	return fmt.Sprintf("%s/%s/%s%s", b.AccountId.ID(), b.ShareName, path, b.FileName)
+}
+
+func (b FileId) String() string {
+	components := []string{
+		fmt.Sprintf("Directory Path %q", b.DirectoryPath),
+		fmt.Sprintf("Share Name %q", b.ShareName),
+		fmt.Sprintf("Account %q", b.AccountId.String()),
+	}
+	return fmt.Sprintf("File %q (%s)", b.FileName, strings.Join(components, " / "))
+}
+
+// ParseFileID parses `input` into a File ID using a known `domainSuffix`
+func ParseFileID(input, domainSuffix string) (*FileId, error) {
+	// example: https://foo.file.core.windows.net/Bar/some/directory/some-file.txt
+	if input == "" {
+		return nil, fmt.Errorf("`input` was empty")
+	}
+
+	account, err := accounts.ParseAccountID(input, domainSuffix)
+	if err != nil {
+		return nil, fmt.Errorf("parsing account %q: %+v", input, err)
+	}
+
+	if account.SubDomainType != accounts.FileSubDomainType {
+		return nil, fmt.Errorf("expected the subdomain type to be %q but got %q", string(accounts.FileSubDomainType), string(account.SubDomainType))
+	}
+
+	uri, err := url.Parse(input)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q as a uri: %+v", input, err)
+	}
+
+	path := strings.TrimPrefix(uri.Path, "/")
+	segments := strings.Split(path, "/")
+	if len(segments) < 2 {
+		return nil, fmt.Errorf("expected the path to contain at least 2 segments but got %d", len(segments))
+	}
+	shareName := segments[0]
+	directoryPath := strings.Join(segments[1:len(segments)-1], "/")
+	fileName := segments[len(segments)-1]
+	return &FileId{
+		AccountId:     *account,
+		ShareName:     shareName,
+		DirectoryPath: directoryPath,
+		FileName:      fileName,
+	}, nil
+}

--- a/storage/2026-02-06/file/files/resource_id_test.go
+++ b/storage/2026-02-06/file/files/resource_id_test.go
@@ -1,0 +1,184 @@
+package files
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+func TestParseFileIDStandard(t *testing.T) {
+	input := "https://example1.file.core.windows.net/share1/some/path/file.txt"
+	expected := FileId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.FileSubDomainType,
+			DomainSuffix:  "core.windows.net",
+		},
+		ShareName:     "share1",
+		DirectoryPath: "some/path",
+		FileName:      "file.txt",
+	}
+	actual, err := ParseFileID(input, "core.windows.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if actual.ShareName != expected.ShareName {
+		t.Fatalf("expected ShareName to be %q but got %q", expected.ShareName, actual.ShareName)
+	}
+	if actual.DirectoryPath != expected.DirectoryPath {
+		t.Fatalf("expected DirectoryPath to be %q but got %q", expected.DirectoryPath, actual.DirectoryPath)
+	}
+	if actual.FileName != expected.FileName {
+		t.Fatalf("expected FileName to be %q but got %q", expected.FileName, actual.FileName)
+	}
+}
+
+func TestParseFileIDInADNSZone(t *testing.T) {
+	input := "https://example1.zone1.file.storage.azure.net/share1/path/file.txt"
+	expected := FileId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.FileSubDomainType,
+			DomainSuffix:  "storage.azure.net",
+			ZoneName:      pointer.To("zone1"),
+		},
+		ShareName:     "share1",
+		DirectoryPath: "path",
+		FileName:      "file.txt",
+	}
+	actual, err := ParseFileID(input, "storage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if pointer.From(actual.AccountId.ZoneName) != pointer.From(expected.AccountId.ZoneName) {
+		t.Fatalf("expected ZoneName to be %q but got %q", pointer.From(expected.AccountId.ZoneName), pointer.From(actual.AccountId.ZoneName))
+	}
+	if actual.ShareName != expected.ShareName {
+		t.Fatalf("expected ShareName to be %q but got %q", expected.ShareName, actual.ShareName)
+	}
+	if actual.DirectoryPath != expected.DirectoryPath {
+		t.Fatalf("expected DirectoryPath to be %q but got %q", expected.DirectoryPath, actual.DirectoryPath)
+	}
+	if actual.FileName != expected.FileName {
+		t.Fatalf("expected FileName to be %q but got %q", expected.FileName, actual.FileName)
+	}
+}
+
+func TestParseFileIDInAnEdgeZone(t *testing.T) {
+	input := "https://example1.file.zone1.edgestorage.azure.net/share1/some/path/file.txt"
+	expected := FileId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.FileSubDomainType,
+			DomainSuffix:  "edgestorage.azure.net",
+			ZoneName:      pointer.To("zone1"),
+			IsEdgeZone:    true,
+		},
+		ShareName:     "share1",
+		DirectoryPath: "some/path",
+		FileName:      "file.txt",
+	}
+	actual, err := ParseFileID(input, "edgestorage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if pointer.From(actual.AccountId.ZoneName) != pointer.From(expected.AccountId.ZoneName) {
+		t.Fatalf("expected ZoneName to be %q but got %q", pointer.From(expected.AccountId.ZoneName), pointer.From(actual.AccountId.ZoneName))
+	}
+	if !actual.AccountId.IsEdgeZone {
+		t.Fatalf("expected the Account to be in an Edge Zone but it wasn't")
+	}
+	if actual.ShareName != expected.ShareName {
+		t.Fatalf("expected ShareName to be %q but got %q", expected.ShareName, actual.ShareName)
+	}
+	if actual.DirectoryPath != expected.DirectoryPath {
+		t.Fatalf("expected DirectoryPath to be %q but got %q", expected.DirectoryPath, actual.DirectoryPath)
+	}
+	if actual.FileName != expected.FileName {
+		t.Fatalf("expected FileName to be %q but got %q", expected.FileName, actual.FileName)
+	}
+}
+
+func TestFormatContainerIDStandard(t *testing.T) {
+	actual := FileId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.FileSubDomainType,
+			DomainSuffix:  "core.windows.net",
+			IsEdgeZone:    false,
+		},
+		ShareName:     "share1",
+		DirectoryPath: "some/path",
+		FileName:      "file.txt",
+	}.ID()
+	expected := "https://example1.file.core.windows.net/share1/some/path/file.txt"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatContainerIDInDNSZone(t *testing.T) {
+	actual := FileId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			ZoneName:      pointer.To("zone2"),
+			SubDomainType: accounts.FileSubDomainType,
+			DomainSuffix:  "storage.azure.net",
+			IsEdgeZone:    false,
+		},
+		ShareName:     "share1",
+		DirectoryPath: "some/path",
+		FileName:      "file.txt",
+	}.ID()
+	expected := "https://example1.zone2.file.storage.azure.net/share1/some/path/file.txt"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatContainerIDInEdgeZone(t *testing.T) {
+	actual := FileId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			ZoneName:      pointer.To("zone2"),
+			SubDomainType: accounts.FileSubDomainType,
+			DomainSuffix:  "edgestorage.azure.net",
+			IsEdgeZone:    true,
+		},
+		ShareName:     "share1",
+		DirectoryPath: "path",
+		FileName:      "file.txt",
+	}.ID()
+	expected := "https://example1.file.zone2.edgestorage.azure.net/share1/path/file.txt"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}

--- a/storage/2026-02-06/file/files/version.go
+++ b/storage/2026-02-06/file/files/version.go
@@ -1,0 +1,4 @@
+package files
+
+const apiVersion = "2026-02-06"
+const componentName = "file/files"

--- a/storage/2026-02-06/file/shares/README.md
+++ b/storage/2026-02-06/file/shares/README.md
@@ -1,0 +1,50 @@
+## File Storage Shares SDK for API version 2026-02-06
+
+This package allows you to interact with the Shares File Storage API
+
+### Supported Authorizers
+
+* Azure Active Directory (for the Resource Endpoint `https://storage.azure.com`)
+* SharedKeyLite (Blob, File & Queue)
+
+### Example Usage
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/file/shares"
+)
+
+func Example() error {
+	accountName := "storageaccount1"
+    storageAccountKey := "ABC123...."
+    shareName := "myshare"
+	domainSuffix := "core.windows.net"
+
+	auth, err := auth.NewSharedKeyAuthorizer(accountName, storageAccountKey, auth.SharedKey)
+	if err != nil {
+		return fmt.Errorf("building SharedKey authorizer: %+v", err)
+	}
+	
+    sharesClient, err := shares.NewWithBaseUri(fmt.Sprintf("https://%s.file.%s", accountName, domainSuffix))
+	if err != nil {
+		return fmt.Errorf("building SharedKey authorizer: %+v", err)
+	}
+    sharesClient.Client.SetAuthorizer(auth)
+    
+    ctx := context.TODO()
+    input := shares.CreateInput{
+    	QuotaInGB: 2,
+    }
+    if _, err := sharesClient.Create(ctx, shareName, input); err != nil {
+        return fmt.Errorf("Error creating Share: %s", err)
+    }
+    
+    return nil 
+}
+```

--- a/storage/2026-02-06/file/shares/acl_get.go
+++ b/storage/2026-02-06/file/shares/acl_get.go
@@ -1,0 +1,83 @@
+package shares
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type GetACLResult struct {
+	HttpResponse *http.Response
+
+	SignedIdentifiers []SignedIdentifier `xml:"SignedIdentifier"`
+}
+
+// GetACL get the Access Control List for the specified Storage Share
+func (c Client) GetACL(ctx context.Context, shareName string) (result GetACLResult, err error) {
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: getAclOptions{},
+		Path:          fmt.Sprintf("/%s", shareName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			err = resp.Unmarshal(&result)
+			if err != nil {
+				err = fmt.Errorf("unmarshalling response: %+v", err)
+				return
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type getAclOptions struct {
+}
+
+func (g getAclOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (g getAclOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (g getAclOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("restype", "share")
+	out.Append("comp", "acl")
+	return out
+}

--- a/storage/2026-02-06/file/shares/acl_set.go
+++ b/storage/2026-02-06/file/shares/acl_set.go
@@ -1,0 +1,95 @@
+package shares
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type SetAclResponse struct {
+	HttpResponse *http.Response
+}
+
+type SetAclInput struct {
+	SignedIdentifiers []SignedIdentifier `xml:"SignedIdentifier"`
+	XMLName           xml.Name           `xml:"SignedIdentifiers"`
+}
+
+// SetACL sets the specified Access Control List on the specified Storage Share
+func (c Client) SetACL(ctx context.Context, shareName string, input SetAclInput) (result SetAclResponse, err error) {
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodPut,
+		OptionsObject: setAclOptions{},
+		Path:          fmt.Sprintf("/%s", shareName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	b, err := xml.Marshal(&input)
+	if err != nil {
+		err = fmt.Errorf("marshalling input: %+v", err)
+		return
+	}
+	withHeader := xml.Header + string(b)
+	bytesWithHeader := []byte(withHeader)
+	req.ContentLength = int64(len(bytesWithHeader))
+	req.Header.Set("Content-Length", strconv.Itoa(len(bytesWithHeader)))
+	req.Body = io.NopCloser(bytes.NewReader(bytesWithHeader))
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type setAclOptions struct {
+	SignedIdentifiers []SignedIdentifier `xml:"SignedIdentifier"`
+}
+
+func (s setAclOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (s setAclOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (s setAclOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("restype", "share")
+	out.Append("comp", "acl")
+	return out
+}

--- a/storage/2026-02-06/file/shares/api.go
+++ b/storage/2026-02-06/file/shares/api.go
@@ -1,0 +1,21 @@
+package shares
+
+import (
+	"context"
+)
+
+type StorageShare interface {
+	SetACL(ctx context.Context, shareName string, input SetAclInput) (SetAclResponse, error)
+	GetSnapshot(ctx context.Context, shareName string, input GetSnapshotPropertiesInput) (GetSnapshotPropertiesResponse, error)
+	GetStats(ctx context.Context, shareName string) (GetStatsResponse, error)
+	GetACL(ctx context.Context, shareName string) (GetACLResult, error)
+	SetMetaData(ctx context.Context, shareName string, input SetMetaDataInput) (SetMetaDataResponse, error)
+	GetMetaData(ctx context.Context, shareName string) (GetMetaDataResponse, error)
+	SetProperties(ctx context.Context, shareName string, properties ShareProperties) (SetPropertiesResponse, error)
+	DeleteSnapshot(ctx context.Context, accountName string, shareName string, shareSnapshot string) (DeleteSnapshotResponse, error)
+	CreateSnapshot(ctx context.Context, shareName string, input CreateSnapshotInput) (CreateSnapshotResponse, error)
+	GetResourceManagerResourceID(subscriptionID, resourceGroup, accountName, shareName string) string
+	GetProperties(ctx context.Context, shareName string) (GetPropertiesResult, error)
+	Delete(ctx context.Context, shareName string, input DeleteInput) (DeleteResponse, error)
+	Create(ctx context.Context, shareName string, input CreateInput) (CreateResponse, error)
+}

--- a/storage/2026-02-06/file/shares/client.go
+++ b/storage/2026-02-06/file/shares/client.go
@@ -1,0 +1,22 @@
+package shares
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/dataplane/storage"
+)
+
+// Client is the base client for File Storage Shares.
+type Client struct {
+	Client *storage.Client
+}
+
+func NewWithBaseUri(baseUri string) (*Client, error) {
+	baseClient, err := storage.NewStorageClient(baseUri, componentName, apiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("building base client: %+v", err)
+	}
+	return &Client{
+		Client: baseClient,
+	}, nil
+}

--- a/storage/2026-02-06/file/shares/create.go
+++ b/storage/2026-02-06/file/shares/create.go
@@ -1,0 +1,158 @@
+package shares
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/lang/response"
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type AccessTier string
+
+const (
+	TransactionOptimizedAccessTier AccessTier = "TransactionOptimized"
+	HotAccessTier                  AccessTier = "Hot"
+	CoolAccessTier                 AccessTier = "Cool"
+	PremiumAccessTier              AccessTier = "Premium"
+)
+
+type CreateInput struct {
+	// Specifies the maximum size of the share, in gigabytes.
+	// Must be greater than 0, and less than or equal to 5TB (5120).
+	QuotaInGB int
+
+	// Specifies the enabled protocols on the share. If not specified, the default is SMB.
+	EnabledProtocol ShareProtocol
+
+	MetaData map[string]string
+
+	// Specifies the access tier of the share.
+	AccessTier *AccessTier
+}
+
+type CreateResponse struct {
+	HttpResponse *http.Response
+}
+
+// Create creates the specified Storage Share within the specified Storage Account
+func (c Client) Create(ctx context.Context, shareName string, input CreateInput) (result CreateResponse, err error) {
+
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if input.QuotaInGB <= 0 || input.QuotaInGB > 102400 {
+		err = fmt.Errorf("`input.QuotaInGB` must be greater than 0, and less than/equal to 100TB (102400 GB)")
+		return
+	}
+
+	if err = metadata.Validate(input.MetaData); err != nil {
+		err = fmt.Errorf("`input.MetaData` is not valid: %s", err)
+		return
+	}
+
+	// Retry the share creation if a conflicting share is still in the process of being deleted
+	retryFunc := func(resp *http.Response, _ *odata.OData) (bool, error) {
+		if resp != nil {
+			if response.WasStatusCode(resp, http.StatusConflict) {
+				// TODO: move this error response parsing to a common helper function
+				respBody, err := io.ReadAll(resp.Body)
+				if err != nil {
+					return false, fmt.Errorf("could not parse response body")
+				}
+				resp.Body.Close()
+				respBody = bytes.TrimPrefix(respBody, []byte("\xef\xbb\xbf"))
+				res := ErrorResponse{}
+				if err = xml.Unmarshal(respBody, &res); err != nil {
+					return false, err
+				}
+				resp.Body = io.NopCloser(bytes.NewBuffer(respBody))
+				if res.Code != nil {
+					return strings.Contains(*res.Code, "ShareBeingDeleted"), nil
+				}
+			}
+		}
+		return false, nil
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: CreateOptions{
+			input: input,
+		},
+		Path:      fmt.Sprintf("/%s", shareName),
+		RetryFunc: retryFunc,
+	}
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type CreateOptions struct {
+	input CreateInput
+}
+
+func (c CreateOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	if len(c.input.MetaData) > 0 {
+		headers.Merge(metadata.SetMetaDataHeaders(c.input.MetaData))
+	}
+
+	protocol := SMB
+	if c.input.EnabledProtocol != "" {
+		protocol = c.input.EnabledProtocol
+	}
+	headers.Append("x-ms-enabled-protocols", string(protocol))
+
+	if c.input.AccessTier != nil {
+		headers.Append("x-ms-access-tier", string(*c.input.AccessTier))
+	}
+
+	headers.Append("x-ms-share-quota", strconv.Itoa(c.input.QuotaInGB))
+
+	return headers
+}
+
+func (c CreateOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (c CreateOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("restype", "share")
+	return out
+}

--- a/storage/2026-02-06/file/shares/delete.go
+++ b/storage/2026-02-06/file/shares/delete.go
@@ -1,0 +1,83 @@
+package shares
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type DeleteResponse struct {
+	HttpResponse *http.Response
+}
+
+type DeleteInput struct {
+	DeleteSnapshots bool
+}
+
+// Delete deletes the specified Storage Share from within a Storage Account
+func (c Client) Delete(ctx context.Context, shareName string, input DeleteInput) (result DeleteResponse, err error) {
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+		},
+		HttpMethod: http.MethodDelete,
+		OptionsObject: DeleteOptions{
+			deleteSnapshots: input.DeleteSnapshots,
+		},
+		Path: fmt.Sprintf("/%s", shareName),
+	}
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type DeleteOptions struct {
+	deleteSnapshots bool
+}
+
+func (d DeleteOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	if d.deleteSnapshots {
+		headers.Append("x-ms-delete-snapshots", "include")
+	}
+	return headers
+}
+
+func (d DeleteOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (d DeleteOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("restype", "share")
+	return out
+}

--- a/storage/2026-02-06/file/shares/lifecycle_test.go
+++ b/storage/2026-02-06/file/shares/lifecycle_test.go
@@ -1,0 +1,387 @@
+package shares
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+var _ StorageShare = Client{}
+
+func TestSharesLifecycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	shareName := fmt.Sprintf("share-%d", testhelpers.RandomInt())
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindStorageVTwo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+	sharesClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.file.%s", accountName, *domainSuffix))
+	if err := client.PrepareWithSharedKeyAuth(sharesClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	tier := CoolAccessTier
+	input := CreateInput{
+		QuotaInGB:  1,
+		AccessTier: &tier,
+	}
+	_, err = sharesClient.Create(ctx, shareName, input)
+	if err != nil {
+		t.Fatalf("Error creating fileshare: %s", err)
+	}
+
+	snapshot, err := sharesClient.CreateSnapshot(ctx, shareName, CreateSnapshotInput{})
+	if err != nil {
+		t.Fatalf("Error taking snapshot: %s", err)
+	}
+	t.Logf("Snapshot Date Time: %s", snapshot.SnapshotDateTime)
+
+	snapshotDetails, err := sharesClient.GetSnapshot(ctx, shareName, GetSnapshotPropertiesInput{snapshotShare: snapshot.SnapshotDateTime})
+	if err != nil {
+		t.Fatalf("Error retrieving snapshot: %s", err)
+	}
+
+	t.Logf("MetaData: %s", snapshotDetails.MetaData)
+
+	_, err = sharesClient.DeleteSnapshot(ctx, accountName, shareName, snapshot.SnapshotDateTime)
+	if err != nil {
+		t.Fatalf("Error deleting snapshot: %s", err)
+	}
+
+	stats, err := sharesClient.GetStats(ctx, shareName)
+	if err != nil {
+		t.Fatalf("Error retrieving stats: %s", err)
+	}
+
+	if stats.ShareUsageBytes != 0 {
+		t.Fatalf("Expected `stats.ShareUsageBytes` to be 0 but got: %d", stats.ShareUsageBytes)
+	}
+
+	share, err := sharesClient.GetProperties(ctx, shareName)
+	if err != nil {
+		t.Fatalf("Error retrieving share: %s", err)
+	}
+	if share.QuotaInGB != 1 {
+		t.Fatalf("Expected Quota to be 1 but got: %d", share.QuotaInGB)
+	}
+	if share.EnabledProtocol != SMB {
+		t.Fatalf("Expected EnabledProtocol to SMB but got: %s", share.EnabledProtocol)
+	}
+	if share.AccessTier == nil || *share.AccessTier != CoolAccessTier {
+		t.Fatalf("Expected AccessTier to be Cool but got: %+v", share.AccessTier)
+	}
+
+	newTier := HotAccessTier
+	quota := 5
+	props := ShareProperties{
+		AccessTier: &newTier,
+		QuotaInGb:  &quota,
+	}
+	_, err = sharesClient.SetProperties(ctx, shareName, props)
+	if err != nil {
+		t.Fatalf("Error updating quota: %s", err)
+	}
+
+	share, err = sharesClient.GetProperties(ctx, shareName)
+	if err != nil {
+		t.Fatalf("Error retrieving share: %s", err)
+	}
+	if share.QuotaInGB != 5 {
+		t.Fatalf("Expected Quota to be 5 but got: %d", share.QuotaInGB)
+	}
+
+	if share.AccessTier == nil || *share.AccessTier != HotAccessTier {
+		t.Fatalf("Expected AccessTier to be Hot but got: %+v", share.AccessTier)
+	}
+
+	updatedMetaData := map[string]string{
+		"hello": "world",
+	}
+
+	_, err = sharesClient.SetMetaData(ctx, shareName, SetMetaDataInput{MetaData: updatedMetaData})
+	if err != nil {
+		t.Fatalf("Erorr setting metadata: %s", err)
+	}
+
+	result, err := sharesClient.GetMetaData(ctx, shareName)
+	if err != nil {
+		t.Fatalf("Error retrieving metadata: %s", err)
+	}
+
+	if result.MetaData["hello"] != "world" {
+		t.Fatalf("Expected metadata `hello` to be `world` but got: %q", result.MetaData["hello"])
+	}
+	if len(result.MetaData) != 1 {
+		t.Fatalf("Expected metadata to be 1 item but got: %s", result.MetaData)
+	}
+
+	acls, err := sharesClient.GetACL(ctx, shareName)
+	if err != nil {
+		t.Fatalf("Error retrieving ACL's: %s", err)
+	}
+	if len(acls.SignedIdentifiers) != 0 {
+		t.Fatalf("Expected 0 identifiers but got %d", len(acls.SignedIdentifiers))
+	}
+
+	updatedAcls := []SignedIdentifier{
+		{
+			Id: "abc123",
+			AccessPolicy: AccessPolicy{
+				Start:      "2020-07-01T08:49:37.0000000Z",
+				Expiry:     "2020-07-01T09:49:37.0000000Z",
+				Permission: "rwd",
+			},
+		},
+		{
+			Id: "bcd234",
+			AccessPolicy: AccessPolicy{
+				Start:      "2020-07-01T08:49:37.0000000Z",
+				Expiry:     "2020-07-01T09:49:37.0000000Z",
+				Permission: "rwd",
+			},
+		},
+	}
+	_, err = sharesClient.SetACL(ctx, shareName, SetAclInput{SignedIdentifiers: updatedAcls})
+	if err != nil {
+		t.Fatalf("Error setting ACL's: %s", err)
+	}
+
+	acls, err = sharesClient.GetACL(ctx, shareName)
+	if err != nil {
+		t.Fatalf("Error retrieving ACL's: %s", err)
+	}
+	if len(acls.SignedIdentifiers) != 2 {
+		t.Fatalf("Expected 2 identifiers but got %d", len(acls.SignedIdentifiers))
+	}
+
+	_, err = sharesClient.Delete(ctx, shareName, DeleteInput{DeleteSnapshots: false})
+	if err != nil {
+		t.Fatalf("Error deleting Share: %s", err)
+	}
+}
+
+func TestSharesLifecycleLargeQuota(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	shareName := fmt.Sprintf("share-%d", testhelpers.RandomInt())
+
+	testData, err := client.BuildTestResourcesWithSku(ctx, resourceGroup, accountName, storageaccounts.KindFileStorage, storageaccounts.SkuNamePremiumLRS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+	sharesClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.file.%s", accountName, *domainSuffix))
+	if err := client.PrepareWithSharedKeyAuth(sharesClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	input := CreateInput{
+		QuotaInGB: 1001,
+	}
+	_, err = sharesClient.Create(ctx, shareName, input)
+	if err != nil {
+		t.Fatalf("Error creating fileshare: %s", err)
+	}
+
+	snapshot, err := sharesClient.CreateSnapshot(ctx, shareName, CreateSnapshotInput{})
+	if err != nil {
+		t.Fatalf("Error taking snapshot: %s", err)
+	}
+	t.Logf("Snapshot Date Time: %s", snapshot.SnapshotDateTime)
+
+	snapshotDetails, err := sharesClient.GetSnapshot(ctx, shareName, GetSnapshotPropertiesInput{snapshotShare: snapshot.SnapshotDateTime})
+	if err != nil {
+		t.Fatalf("Error retrieving snapshot: %s", err)
+	}
+
+	t.Logf("MetaData: %s", snapshotDetails.MetaData)
+
+	_, err = sharesClient.DeleteSnapshot(ctx, accountName, shareName, snapshot.SnapshotDateTime)
+	if err != nil {
+		t.Fatalf("Error deleting snapshot: %s", err)
+	}
+
+	stats, err := sharesClient.GetStats(ctx, shareName)
+	if err != nil {
+		t.Fatalf("Error retrieving stats: %s", err)
+	}
+
+	if stats.ShareUsageBytes != 0 {
+		t.Fatalf("Expected `stats.ShareUsageBytes` to be 0 but got: %d", stats.ShareUsageBytes)
+	}
+
+	share, err := sharesClient.GetProperties(ctx, shareName)
+	if err != nil {
+		t.Fatalf("Error retrieving share: %s", err)
+	}
+	if share.QuotaInGB != 1001 {
+		t.Fatalf("Expected Quota to be 1001 but got: %d", share.QuotaInGB)
+	}
+
+	newQuota := 6000
+	props := ShareProperties{
+		QuotaInGb: &newQuota,
+	}
+	_, err = sharesClient.SetProperties(ctx, shareName, props)
+	if err != nil {
+		t.Fatalf("Error updating quota: %s", err)
+	}
+
+	share, err = sharesClient.GetProperties(ctx, shareName)
+	if err != nil {
+		t.Fatalf("Error retrieving share: %s", err)
+	}
+	if share.QuotaInGB != 6000 {
+		t.Fatalf("Expected Quota to be 6000 but got: %d", share.QuotaInGB)
+	}
+
+	updatedMetaData := map[string]string{
+		"hello": "world",
+	}
+
+	_, err = sharesClient.SetMetaData(ctx, shareName, SetMetaDataInput{MetaData: updatedMetaData})
+	if err != nil {
+		t.Fatalf("Erorr setting metadata: %s", err)
+	}
+
+	result, err := sharesClient.GetMetaData(ctx, shareName)
+	if err != nil {
+		t.Fatalf("Error retrieving metadata: %s", err)
+	}
+
+	if result.MetaData["hello"] != "world" {
+		t.Fatalf("Expected metadata `hello` to be `world` but got: %q", result.MetaData["hello"])
+	}
+	if len(result.MetaData) != 1 {
+		t.Fatalf("Expected metadata to be 1 item but got: %s", result.MetaData)
+	}
+
+	acls, err := sharesClient.GetACL(ctx, shareName)
+	if err != nil {
+		t.Fatalf("Error retrieving ACL's: %s", err)
+	}
+	if len(acls.SignedIdentifiers) != 0 {
+		t.Fatalf("Expected 0 identifiers but got %d", len(acls.SignedIdentifiers))
+	}
+
+	updatedAcls := []SignedIdentifier{
+		{
+			Id: "abc123",
+			AccessPolicy: AccessPolicy{
+				Start:      "2020-07-01T08:49:37.0000000Z",
+				Expiry:     "2020-07-01T09:49:37.0000000Z",
+				Permission: "rwd",
+			},
+		},
+		{
+			Id: "bcd234",
+			AccessPolicy: AccessPolicy{
+				Start:      "2020-07-01T08:49:37.0000000Z",
+				Expiry:     "2020-07-01T09:49:37.0000000Z",
+				Permission: "rwd",
+			},
+		},
+	}
+	_, err = sharesClient.SetACL(ctx, shareName, SetAclInput{SignedIdentifiers: updatedAcls})
+	if err != nil {
+		t.Fatalf("Error setting ACL's: %s", err)
+	}
+
+	acls, err = sharesClient.GetACL(ctx, shareName)
+	if err != nil {
+		t.Fatalf("Error retrieving ACL's: %s", err)
+	}
+	if len(acls.SignedIdentifiers) != 2 {
+		t.Fatalf("Expected 2 identifiers but got %d", len(acls.SignedIdentifiers))
+	}
+
+	_, err = sharesClient.Delete(ctx, shareName, DeleteInput{DeleteSnapshots: false})
+	if err != nil {
+		t.Fatalf("Error deleting Share: %s", err)
+	}
+}
+
+func TestSharesLifecycleNFSProtocol(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	shareName := fmt.Sprintf("share-%d", testhelpers.RandomInt())
+
+	testData, err := client.BuildTestResourcesWithSku(ctx, resourceGroup, accountName, storageaccounts.KindFileStorage, storageaccounts.SkuNamePremiumLRS)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+	sharesClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.file.%s", accountName, *domainSuffix))
+	if err := client.PrepareWithSharedKeyAuth(sharesClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	input := CreateInput{
+		QuotaInGB:       1000,
+		EnabledProtocol: NFS,
+	}
+	_, err = sharesClient.Create(ctx, shareName, input)
+	if err != nil {
+		t.Fatalf("Error creating fileshare: %s", err)
+	}
+
+	share, err := sharesClient.GetProperties(ctx, shareName)
+	if err != nil {
+		t.Fatalf("Error retrieving share: %s", err)
+	}
+	if share.EnabledProtocol != NFS {
+		t.Fatalf(`Expected enabled protocol to be "NFS" but got: %q`, share.EnabledProtocol)
+	}
+
+	_, err = sharesClient.Delete(ctx, shareName, DeleteInput{DeleteSnapshots: false})
+	if err != nil {
+		t.Fatalf("Error deleting Share: %s", err)
+	}
+}

--- a/storage/2026-02-06/file/shares/metadata_get.go
+++ b/storage/2026-02-06/file/shares/metadata_get.go
@@ -1,0 +1,79 @@
+package shares
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type GetMetaDataResponse struct {
+	HttpResponse *http.Response
+
+	MetaData map[string]string
+}
+
+// GetMetaData returns the MetaData associated with the specified Storage Share
+func (c Client) GetMetaData(ctx context.Context, shareName string) (result GetMetaDataResponse, err error) {
+	if shareName == "" {
+		return result, fmt.Errorf("`shareName` cannot be an empty string")
+	}
+	if strings.ToLower(shareName) != shareName {
+		return result, fmt.Errorf("`shareName` must be a lower-cased string")
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: GetMetaDataOptions{},
+		Path:          fmt.Sprintf("/%s", shareName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.MetaData = metadata.ParseFromHeaders(resp.Header)
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type GetMetaDataOptions struct{}
+
+func (g GetMetaDataOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (g GetMetaDataOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (g GetMetaDataOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("restype", "share")
+	out.Append("comp", "metadata")
+	return out
+}

--- a/storage/2026-02-06/file/shares/metadata_set.go
+++ b/storage/2026-02-06/file/shares/metadata_set.go
@@ -1,0 +1,89 @@
+package shares
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type SetMetaDataResponse struct {
+	HttpResponse *http.Response
+}
+
+type SetMetaDataInput struct {
+	MetaData map[string]string
+}
+
+// SetMetaData sets the MetaData on the specified Storage Share
+func (c Client) SetMetaData(ctx context.Context, shareName string, input SetMetaDataInput) (result SetMetaDataResponse, err error) {
+
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if err = metadata.Validate(input.MetaData); err != nil {
+		err = fmt.Errorf("`metadata` is not valid: %+v", err)
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: SetMetaDataOptions{
+			metaData: input.MetaData,
+		},
+		Path: fmt.Sprintf("/%s", shareName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type SetMetaDataOptions struct {
+	metaData map[string]string
+}
+
+func (s SetMetaDataOptions) ToHeaders() *client.Headers {
+	headers := metadata.SetMetaDataHeaders(s.metaData)
+	return &headers
+}
+
+func (s SetMetaDataOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (s SetMetaDataOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("restype", "share")
+	out.Append("comp", "metadata")
+	return out
+}

--- a/storage/2026-02-06/file/shares/models.go
+++ b/storage/2026-02-06/file/shares/models.go
@@ -1,0 +1,30 @@
+package shares
+
+import "encoding/xml"
+
+type SignedIdentifier struct {
+	Id           string       `xml:"Id"`
+	AccessPolicy AccessPolicy `xml:"AccessPolicy"`
+}
+
+type AccessPolicy struct {
+	Start      string `xml:"Start"`
+	Expiry     string `xml:"Expiry"`
+	Permission string `xml:"Permission"`
+}
+
+type ShareProtocol string
+
+const (
+	// SMB indicates the share can be accessed by SMBv3.0, SMBv2.1 and REST.
+	SMB ShareProtocol = "SMB"
+
+	// NFS indicates the share can be accessed by NFSv4.1. A premium account is required for this option.
+	NFS ShareProtocol = "NFS"
+)
+
+type ErrorResponse struct {
+	XMLName xml.Name `xml:"Error"`
+	Code    *string  `xml:"Code"`
+	Message *string  `xml:"Message"`
+}

--- a/storage/2026-02-06/file/shares/options.go
+++ b/storage/2026-02-06/file/shares/options.go
@@ -1,0 +1,24 @@
+package shares
+
+import (
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+var _ client.Options = sharesOptions{}
+
+type sharesOptions struct{}
+
+func (o sharesOptions) ToHeaders() *client.Headers {
+	return &client.Headers{}
+}
+
+func (sharesOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (sharesOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("restype", "share")
+	return out
+}

--- a/storage/2026-02-06/file/shares/properties_get.go
+++ b/storage/2026-02-06/file/shares/properties_get.go
@@ -1,0 +1,89 @@
+package shares
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type GetPropertiesResult struct {
+	HttpResponse *http.Response
+
+	MetaData        map[string]string
+	QuotaInGB       int
+	EnabledProtocol ShareProtocol
+	AccessTier      *AccessTier
+}
+
+// GetProperties returns the properties about the specified Storage Share
+func (c Client) GetProperties(ctx context.Context, shareName string) (result GetPropertiesResult, err error) {
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: sharesOptions{},
+		Path:          fmt.Sprintf("/%s", shareName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.MetaData = metadata.ParseFromHeaders(resp.Header)
+
+				quotaRaw := resp.Header.Get("x-ms-share-quota")
+				if quotaRaw != "" {
+					quota, e := strconv.Atoi(quotaRaw)
+					if e != nil {
+						err = fmt.Errorf("error converting %q to an integer: %s", quotaRaw, err)
+						return
+					}
+					result.QuotaInGB = quota
+				}
+
+				protocol := SMB
+				if protocolRaw := resp.Header.Get("x-ms-enabled-protocols"); protocolRaw != "" {
+					protocol = ShareProtocol(protocolRaw)
+				}
+
+				if accessTierRaw := resp.Header.Get("x-ms-access-tier"); accessTierRaw != "" {
+					tier := AccessTier(accessTierRaw)
+					result.AccessTier = &tier
+				}
+				result.EnabledProtocol = protocol
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}

--- a/storage/2026-02-06/file/shares/properties_set.go
+++ b/storage/2026-02-06/file/shares/properties_set.go
@@ -1,0 +1,94 @@
+package shares
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type ShareProperties struct {
+	QuotaInGb  *int
+	AccessTier *AccessTier
+}
+
+type SetPropertiesResponse struct {
+	HttpResponse *http.Response
+}
+
+// SetProperties lets you update the Quota for the specified Storage Share
+func (c Client) SetProperties(ctx context.Context, shareName string, properties ShareProperties) (result SetPropertiesResponse, err error) {
+
+	if shareName == "" {
+		return result, fmt.Errorf("`shareName` cannot be an empty string")
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		return result, fmt.Errorf("`shareName` must be a lower-cased string")
+	}
+
+	if newQuotaGB := properties.QuotaInGb; newQuotaGB != nil && (*newQuotaGB <= 0 || *newQuotaGB > 102400) {
+		return result, fmt.Errorf("`newQuotaGB` must be greater than 0, and less than/equal to 100TB (102400 GB)")
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: SetPropertiesOptions{
+			input: properties,
+		},
+		Path: fmt.Sprintf("/%s", shareName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type SetPropertiesOptions struct {
+	input ShareProperties
+}
+
+func (s SetPropertiesOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	if s.input.QuotaInGb != nil {
+		headers.Append("x-ms-share-quota", strconv.Itoa(*s.input.QuotaInGb))
+	}
+
+	if s.input.AccessTier != nil {
+		headers.Append("x-ms-access-tier", string(*s.input.AccessTier))
+	}
+	return headers
+}
+
+func (s SetPropertiesOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (s SetPropertiesOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("restype", "share")
+	out.Append("comp", "properties")
+	return out
+}

--- a/storage/2026-02-06/file/shares/resource_id.go
+++ b/storage/2026-02-06/file/shares/resource_id.go
@@ -1,0 +1,81 @@
+package shares
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+// GetResourceManagerResourceID returns the Resource Manager specific
+// ResourceID for a specific Storage Share
+func (c Client) GetResourceManagerResourceID(subscriptionID, resourceGroup, accountName, shareName string) string {
+	fmtStr := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/fileServices/default/shares/%s"
+	return fmt.Sprintf(fmtStr, subscriptionID, resourceGroup, accountName, shareName)
+}
+
+// TODO: update this to implement `resourceids.ResourceId` once
+// https://github.com/hashicorp/go-azure-helpers/issues/187 is fixed
+var _ resourceids.Id = ShareId{}
+
+type ShareId struct {
+	// AccountId specifies the ID of the Storage Account where this File Share exists.
+	AccountId accounts.AccountId
+
+	// ShareName specifies the name of this File Share.
+	ShareName string
+}
+
+func NewShareID(accountId accounts.AccountId, shareName string) ShareId {
+	return ShareId{
+		AccountId: accountId,
+		ShareName: shareName,
+	}
+}
+
+func (b ShareId) ID() string {
+	return fmt.Sprintf("%s/%s", b.AccountId.ID(), b.ShareName)
+}
+
+func (b ShareId) String() string {
+	components := []string{
+		fmt.Sprintf("Account %q", b.AccountId.String()),
+	}
+	return fmt.Sprintf("File Share %q (%s)", b.ShareName, strings.Join(components, " / "))
+}
+
+// ParseShareID parses `input` into a Share ID using a known `domainSuffix`
+func ParseShareID(input, domainSuffix string) (*ShareId, error) {
+	// example: https://foo.file.core.windows.net/Bar
+	if input == "" {
+		return nil, fmt.Errorf("`input` was empty")
+	}
+
+	account, err := accounts.ParseAccountID(input, domainSuffix)
+	if err != nil {
+		return nil, fmt.Errorf("parsing account %q: %+v", input, err)
+	}
+
+	if account.SubDomainType != accounts.FileSubDomainType {
+		return nil, fmt.Errorf("expected the subdomain type to be %q but got %q", string(accounts.FileSubDomainType), string(account.SubDomainType))
+	}
+
+	uri, err := url.Parse(input)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q as a uri: %+v", input, err)
+	}
+
+	path := strings.TrimPrefix(uri.Path, "/")
+	segments := strings.Split(path, "/")
+	if len(segments) == 0 {
+		return nil, fmt.Errorf("expected the path to contain segments but got none")
+	}
+
+	shareName := strings.TrimPrefix(uri.Path, "/")
+	return &ShareId{
+		AccountId: *account,
+		ShareName: shareName,
+	}, nil
+}

--- a/storage/2026-02-06/file/shares/resource_id_test.go
+++ b/storage/2026-02-06/file/shares/resource_id_test.go
@@ -1,0 +1,162 @@
+package shares
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+func TestGetResourceManagerResourceID(t *testing.T) {
+	actual := Client{}.GetResourceManagerResourceID("11112222-3333-4444-5555-666677778888", "group1", "account1", "share1")
+	expected := "/subscriptions/11112222-3333-4444-5555-666677778888/resourceGroups/group1/providers/Microsoft.Storage/storageAccounts/account1/fileServices/default/shares/share1"
+	if actual != expected {
+		t.Fatalf("Expected the Resource Manager Resource ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseShareIDStandard(t *testing.T) {
+	input := "https://example1.file.core.windows.net/share1"
+	expected := ShareId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.FileSubDomainType,
+			DomainSuffix:  "core.windows.net",
+		},
+		ShareName: "share1",
+	}
+	actual, err := ParseShareID(input, "core.windows.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if actual.ShareName != expected.ShareName {
+		t.Fatalf("expected ShareName to be %q but got %q", expected.ShareName, actual.ShareName)
+	}
+}
+
+func TestParseShareIDInADNSZone(t *testing.T) {
+	input := "https://example1.zone1.file.storage.azure.net/share1"
+	expected := ShareId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.FileSubDomainType,
+			DomainSuffix:  "storage.azure.net",
+			ZoneName:      pointer.To("zone1"),
+		},
+		ShareName: "share1",
+	}
+	actual, err := ParseShareID(input, "storage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if pointer.From(actual.AccountId.ZoneName) != pointer.From(expected.AccountId.ZoneName) {
+		t.Fatalf("expected ZoneName to be %q but got %q", pointer.From(expected.AccountId.ZoneName), pointer.From(actual.AccountId.ZoneName))
+	}
+	if actual.ShareName != expected.ShareName {
+		t.Fatalf("expected ShareName to be %q but got %q", expected.ShareName, actual.ShareName)
+	}
+}
+
+func TestParseShareIDInAnEdgeZone(t *testing.T) {
+	input := "https://example1.file.zone1.edgestorage.azure.net/share1"
+	expected := ShareId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.FileSubDomainType,
+			DomainSuffix:  "edgestorage.azure.net",
+			ZoneName:      pointer.To("zone1"),
+			IsEdgeZone:    true,
+		},
+		ShareName: "share1",
+	}
+	actual, err := ParseShareID(input, "edgestorage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if pointer.From(actual.AccountId.ZoneName) != pointer.From(expected.AccountId.ZoneName) {
+		t.Fatalf("expected ZoneName to be %q but got %q", pointer.From(expected.AccountId.ZoneName), pointer.From(actual.AccountId.ZoneName))
+	}
+	if !actual.AccountId.IsEdgeZone {
+		t.Fatalf("expected the Account to be in an Edge Zone but it wasn't")
+	}
+	if actual.ShareName != expected.ShareName {
+		t.Fatalf("expected ShareName to be %q but got %q", expected.ShareName, actual.ShareName)
+	}
+}
+
+func TestFormatContainerIDStandard(t *testing.T) {
+	actual := ShareId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.FileSubDomainType,
+			DomainSuffix:  "core.windows.net",
+			IsEdgeZone:    false,
+		},
+		ShareName: "share1",
+	}.ID()
+	expected := "https://example1.file.core.windows.net/share1"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatContainerIDInDNSZone(t *testing.T) {
+	actual := ShareId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			ZoneName:      pointer.To("zone2"),
+			SubDomainType: accounts.FileSubDomainType,
+			DomainSuffix:  "storage.azure.net",
+			IsEdgeZone:    false,
+		},
+		ShareName: "share1",
+	}.ID()
+	expected := "https://example1.zone2.file.storage.azure.net/share1"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatContainerIDInEdgeZone(t *testing.T) {
+	actual := ShareId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			ZoneName:      pointer.To("zone2"),
+			SubDomainType: accounts.FileSubDomainType,
+			DomainSuffix:  "edgestorage.azure.net",
+			IsEdgeZone:    true,
+		},
+		ShareName: "share1",
+	}.ID()
+	expected := "https://example1.file.zone2.edgestorage.azure.net/share1"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}

--- a/storage/2026-02-06/file/shares/snapshot_create.go
+++ b/storage/2026-02-06/file/shares/snapshot_create.go
@@ -1,0 +1,102 @@
+package shares
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type CreateSnapshotInput struct {
+	MetaData map[string]string
+}
+
+type CreateSnapshotResponse struct {
+	HttpResponse *http.Response
+
+	// This header is a DateTime value that uniquely identifies the share snapshot.
+	// The value of this header may be used in subsequent requests to access the share snapshot.
+	// This value is opaque.
+	SnapshotDateTime string
+}
+
+// CreateSnapshot creates a read-only snapshot of the share
+// A share can support creation of 200 share snapshots. Attempting to create more than 200 share snapshots fails with 409 (Conflict).
+// Attempting to create a share snapshot while a previous Snapshot Share operation is in progress fails with 409 (Conflict).
+func (c Client) CreateSnapshot(ctx context.Context, shareName string, input CreateSnapshotInput) (result CreateSnapshotResponse, err error) {
+
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if err = metadata.Validate(input.MetaData); err != nil {
+		err = fmt.Errorf("`input.MetaData` is not valid: %+v", err)
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: snapShotCreateOptions{
+			metaData: input.MetaData,
+		},
+		Path: fmt.Sprintf("/%s", shareName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.SnapshotDateTime = resp.Header.Get("x-ms-snapshot")
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type snapShotCreateOptions struct {
+	metaData map[string]string
+}
+
+func (s snapShotCreateOptions) ToHeaders() *client.Headers {
+	headers := metadata.SetMetaDataHeaders(s.metaData)
+	return &headers
+}
+
+func (s snapShotCreateOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (s snapShotCreateOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("restype", "share")
+	out.Append("comp", "snapshot")
+	return out
+}

--- a/storage/2026-02-06/file/shares/snapshot_delete.go
+++ b/storage/2026-02-06/file/shares/snapshot_delete.go
@@ -1,0 +1,80 @@
+package shares
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type DeleteSnapshotResponse struct {
+	HttpResponse *http.Response
+}
+
+// DeleteSnapshot deletes the specified Snapshot of a Storage Share
+func (c Client) DeleteSnapshot(ctx context.Context, accountName, shareName string, shareSnapshot string) (result DeleteSnapshotResponse, err error) {
+
+	if shareName == "" {
+		return result, fmt.Errorf("`shareName` cannot be an empty string")
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		return result, fmt.Errorf("`shareName` must be a lower-cased string")
+	}
+
+	if shareSnapshot == "" {
+		return result, fmt.Errorf("`shareSnapshot` cannot be an empty string")
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+		},
+		HttpMethod: http.MethodDelete,
+		OptionsObject: snapShotDeleteOptions{
+			shareSnapShot: shareSnapshot,
+		},
+		Path: fmt.Sprintf("/%s", shareName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type snapShotDeleteOptions struct {
+	shareSnapShot string
+}
+
+func (s snapShotDeleteOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (s snapShotDeleteOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (s snapShotDeleteOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("restype", "share")
+	out.Append("sharesnapshot", s.shareSnapShot)
+	return out
+}

--- a/storage/2026-02-06/file/shares/snapshot_get.go
+++ b/storage/2026-02-06/file/shares/snapshot_get.go
@@ -1,0 +1,95 @@
+package shares
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type GetSnapshotPropertiesResponse struct {
+	HttpResponse *http.Response
+
+	MetaData map[string]string
+}
+
+type GetSnapshotPropertiesInput struct {
+	snapshotShare string
+}
+
+// GetSnapshot gets information about the specified Snapshot of the specified Storage Share
+func (c Client) GetSnapshot(ctx context.Context, shareName string, input GetSnapshotPropertiesInput) (result GetSnapshotPropertiesResponse, err error) {
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	if input.snapshotShare == "" {
+		err = fmt.Errorf("`snapshotShare` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		OptionsObject: snapShotGetOptions{
+			snapshotShare: input.snapshotShare,
+		},
+		Path: fmt.Sprintf("/%s", shareName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.MetaData = metadata.ParseFromHeaders(resp.Header)
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type snapShotGetOptions struct {
+	snapshotShare string
+}
+
+func (s snapShotGetOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (s snapShotGetOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (s snapShotGetOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("restype", "share")
+	out.Append("snapshot", s.snapshotShare)
+	return out
+}

--- a/storage/2026-02-06/file/shares/stats.go
+++ b/storage/2026-02-06/file/shares/stats.go
@@ -1,0 +1,83 @@
+package shares
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type GetStatsResponse struct {
+	HttpResponse *http.Response
+
+	// The approximate size of the data stored on the share.
+	// Note that this value may not include all recently created or recently resized files.
+	ShareUsageBytes int64 `xml:"ShareUsageBytes"`
+}
+
+// GetStats returns information about the specified Storage Share
+func (c Client) GetStats(ctx context.Context, shareName string) (result GetStatsResponse, err error) {
+	if shareName == "" {
+		err = fmt.Errorf("`shareName` cannot be an empty string")
+		return
+	}
+
+	if strings.ToLower(shareName) != shareName {
+		err = fmt.Errorf("`shareName` must be a lower-cased string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: statsOptions{},
+		Path:          shareName,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil {
+		result.HttpResponse = resp.Response
+
+		err = resp.Unmarshal(&result)
+		if err != nil {
+			err = fmt.Errorf("unmarshalling response: %+v", err)
+			return
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type statsOptions struct{}
+
+func (s statsOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (s statsOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (s statsOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("restype", "share")
+	out.Append("comp", "stats")
+	return out
+}

--- a/storage/2026-02-06/file/shares/version.go
+++ b/storage/2026-02-06/file/shares/version.go
@@ -1,0 +1,4 @@
+package shares
+
+const apiVersion = "2026-02-06"
+const componentName = "file/shares"

--- a/storage/2026-02-06/queue/messages/README.md
+++ b/storage/2026-02-06/queue/messages/README.md
@@ -1,0 +1,50 @@
+## Queue Storage Messages SDK for API version 2026-02-06
+
+This package allows you to interact with the Messages Queue Storage API
+
+### Supported Authorizers
+
+* Azure Active Directory (for the Resource Endpoint `https://storage.azure.com`)
+* SharedKeyLite (Blob, File & Queue)
+
+### Example Usage
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/queue/messages"
+)
+
+func Example() error {
+	accountName := "storageaccount1"
+    storageAccountKey := "ABC123...."
+    queueName := "myqueue"
+	domainSuffix := "core.windows.net"
+
+	auth, err := auth.NewSharedKeyAuthorizer(accountName, storageAccountKey, auth.SharedKey)
+	if err != nil {
+		return fmt.Errorf("building SharedKey authorizer: %+v", err)
+	}
+    
+    messagesClient, err  := messages.NewWithBaseUri(fmt.Sprintf("https://%s.queue.%s", accountName, domainSuffix))
+	if err != nil {
+		return fmt.Errorf("building client for environment: %+v", err)
+	}
+    messagesClient.Client.SetAuthorizer(auth)
+    
+    ctx := context.TODO()
+    input := messages.PutInput{
+    	Message: "<over><message>hello</message></over>",
+    }
+    if _, err := messagesClient.Put(ctx, queueName, input); err != nil {
+        return fmt.Errorf("Error creating Message: %s", err)
+    }
+    
+    return nil 
+}
+```

--- a/storage/2026-02-06/queue/messages/api.go
+++ b/storage/2026-02-06/queue/messages/api.go
@@ -1,0 +1,13 @@
+package messages
+
+import (
+	"context"
+)
+
+type StorageQueueMessage interface {
+	Delete(ctx context.Context, queueName string, messageID string, input DeleteInput) (DeleteResponse, error)
+	Peek(ctx context.Context, queueName string, input PeekInput) (QueueMessagesListResponse, error)
+	Put(ctx context.Context, queueName string, input PutInput) (QueueMessagesListResponse, error)
+	Get(ctx context.Context, queueName string, input GetInput) (QueueMessagesListResponse, error)
+	Update(ctx context.Context, queueName string, messageID string, input UpdateInput) (UpdateResponse, error)
+}

--- a/storage/2026-02-06/queue/messages/client.go
+++ b/storage/2026-02-06/queue/messages/client.go
@@ -1,0 +1,22 @@
+package messages
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/dataplane/storage"
+)
+
+// Client is the base client for Messages.
+type Client struct {
+	Client *storage.Client
+}
+
+func NewWithBaseUri(baseUri string) (*Client, error) {
+	baseClient, err := storage.NewStorageClient(baseUri, componentName, apiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("building base client: %+v", err)
+	}
+	return &Client{
+		Client: baseClient,
+	}, nil
+}

--- a/storage/2026-02-06/queue/messages/delete.go
+++ b/storage/2026-02-06/queue/messages/delete.go
@@ -1,0 +1,87 @@
+package messages
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type DeleteResponse struct {
+	HttpResponse *http.Response
+}
+
+type DeleteInput struct {
+	PopReceipt string
+}
+
+// Delete deletes a specific message
+func (c Client) Delete(ctx context.Context, queueName, messageID string, input DeleteInput) (result DeleteResponse, err error) {
+
+	if queueName == "" {
+		return result, fmt.Errorf("`queueName` cannot be an empty string")
+	}
+
+	if strings.ToLower(queueName) != queueName {
+		return result, fmt.Errorf("`queueName` must be a lower-cased string")
+	}
+
+	if messageID == "" {
+		return result, fmt.Errorf("`messageID` cannot be an empty string")
+	}
+
+	if input.PopReceipt == "" {
+		return result, fmt.Errorf("`input.PopReceipt` cannot be an empty string")
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodDelete,
+		OptionsObject: deleteOptions{
+			popReceipt: input.PopReceipt,
+		},
+		Path: fmt.Sprintf("/%s/messages/%s", queueName, messageID),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type deleteOptions struct {
+	popReceipt string
+}
+
+func (d deleteOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (d deleteOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (d deleteOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("popreceipt", d.popReceipt)
+	return out
+}

--- a/storage/2026-02-06/queue/messages/get.go
+++ b/storage/2026-02-06/queue/messages/get.go
@@ -1,0 +1,104 @@
+package messages
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type GetInput struct {
+	// VisibilityTimeout specifies the new visibility timeout value, in seconds, relative to server time.
+	// The new value must be larger than or equal to 0, and cannot be larger than 7 days.
+	VisibilityTimeout *int
+
+	// NumberOfMessages specifies the (maximum) number of messages that should be retrieved from the queue.
+	// This can be a maximum of 32.
+	NumberOfMessages int
+}
+
+// Get retrieves one or more messages from the front of the queue
+func (c Client) Get(ctx context.Context, queueName string, input GetInput) (result QueueMessagesListResponse, err error) {
+	if queueName == "" {
+		return result, fmt.Errorf("`queueName` cannot be an empty string")
+	}
+	if strings.ToLower(queueName) != queueName {
+		return result, fmt.Errorf("`queueName` must be a lower-cased string")
+	}
+	if input.NumberOfMessages < 1 || input.NumberOfMessages > 32 {
+		return result, fmt.Errorf("`input.NumberOfMessages` must be between 1 and 32")
+	}
+	if input.VisibilityTimeout != nil {
+		t := *input.VisibilityTimeout
+		maxTime := (time.Hour * 24 * 7).Seconds()
+		if t < 1 || t < int(maxTime) {
+			return result, fmt.Errorf("`input.VisibilityTimeout` must be larger than or equal to 1 second, and cannot be larger than 7 days")
+		}
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		OptionsObject: getOptions{
+			visibilityTimeout: input.VisibilityTimeout,
+			numberOfMessages:  input.NumberOfMessages,
+		},
+		Path: fmt.Sprintf("/%s/messages", queueName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			err = resp.Unmarshal(&result)
+			if err != nil {
+				err = fmt.Errorf("unmarshalling response: %+v", err)
+				return
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type getOptions struct {
+	visibilityTimeout *int
+	numberOfMessages  int
+}
+
+func (g getOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (g getOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (g getOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	if g.visibilityTimeout != nil {
+		out.Append("visibilitytimeout", strconv.Itoa(*g.visibilityTimeout))
+	}
+	out.Append("numofmessages", strconv.Itoa(g.numberOfMessages))
+	return out
+}

--- a/storage/2026-02-06/queue/messages/lifecycle_test.go
+++ b/storage/2026-02-06/queue/messages/lifecycle_test.go
@@ -1,0 +1,116 @@
+package messages
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2020-08-04/queue/queues"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+var _ StorageQueueMessage = Client{}
+
+func TestLifeCycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	queueName := fmt.Sprintf("queue-%d", testhelpers.RandomInt())
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+	queuesClient, err := queues.NewWithBaseUri(fmt.Sprintf("https://%s.%s.%s", accountName, "queue", *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err := client.PrepareWithSharedKeyAuth(queuesClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	messagesClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.%s.%s", accountName, "queue", *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err := client.PrepareWithSharedKeyAuth(messagesClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	_, err = queuesClient.Create(ctx, queueName, queues.CreateInput{MetaData: map[string]string{}})
+	if err != nil {
+		t.Fatalf("Error creating queue: %s", err)
+	}
+	defer queuesClient.Delete(ctx, queueName)
+
+	input := PutInput{
+		Message: "ohhai",
+	}
+	putResp, err := messagesClient.Put(ctx, queueName, input)
+	if err != nil {
+		t.Fatalf("Error putting message in queue: %s", err)
+	}
+
+	messageId := (*putResp.QueueMessages)[0].MessageId
+	popReceipt := (*putResp.QueueMessages)[0].PopReceipt
+
+	_, err = messagesClient.Update(ctx, queueName, messageId, UpdateInput{
+		PopReceipt:        popReceipt,
+		Message:           "Updated message",
+		VisibilityTimeout: 65,
+	})
+	if err != nil {
+		t.Fatalf("Error updating: %s", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		input := PutInput{
+			Message: fmt.Sprintf("Message %d", i),
+		}
+		_, err := messagesClient.Put(ctx, queueName, input)
+		if err != nil {
+			t.Fatalf("Error putting message %d in queue: %s", i, err)
+		}
+	}
+
+	peakedMessages, err := messagesClient.Peek(ctx, queueName, PeekInput{NumberOfMessages: 3})
+	if err != nil {
+		t.Fatalf("Error peaking messages: %s", err)
+	}
+
+	for _, v := range *peakedMessages.QueueMessages {
+		t.Logf("Message: %q", v.MessageId)
+	}
+
+	retrievedMessages, err := messagesClient.Get(ctx, queueName, GetInput{NumberOfMessages: 6})
+	if err != nil {
+		t.Fatalf("Error retrieving messages: %s", err)
+	}
+
+	for _, v := range *retrievedMessages.QueueMessages {
+		t.Logf("Message: %q", v.MessageId)
+
+		_, err = messagesClient.Delete(ctx, queueName, v.MessageId, DeleteInput{PopReceipt: v.PopReceipt})
+		if err != nil {
+			t.Fatalf("Error deleting message from queue: %s", err)
+		}
+	}
+}

--- a/storage/2026-02-06/queue/messages/lifecycle_test.go
+++ b/storage/2026-02-06/queue/messages/lifecycle_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
-	"github.com/jackofallops/giovanni/storage/2020-08-04/queue/queues"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/queue/queues"
 	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
 )
 

--- a/storage/2026-02-06/queue/messages/models.go
+++ b/storage/2026-02-06/queue/messages/models.go
@@ -1,0 +1,23 @@
+package messages
+
+import (
+	"net/http"
+)
+
+type QueueMessage struct {
+	MessageText string `xml:"MessageText"`
+}
+
+type QueueMessagesListResponse struct {
+	HttpResponse *http.Response
+
+	QueueMessages *[]QueueMessageResponse `xml:"QueueMessage"`
+}
+
+type QueueMessageResponse struct {
+	MessageId       string `xml:"MessageId"`
+	InsertionTime   string `xml:"InsertionTime"`
+	ExpirationTime  string `xml:"ExpirationTime"`
+	PopReceipt      string `xml:"PopReceipt"`
+	TimeNextVisible string `xml:"TimeNextVisible"`
+}

--- a/storage/2026-02-06/queue/messages/peek.go
+++ b/storage/2026-02-06/queue/messages/peek.go
@@ -1,0 +1,91 @@
+package messages
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type PeekInput struct {
+	// NumberOfMessages specifies the (maximum) number of messages that should be peak'd from the front of the queue.
+	// This can be a maximum of 32.
+	NumberOfMessages int
+}
+
+// Peek retrieves one or more messages from the front of the queue, but doesn't alter the visibility of the messages
+func (c Client) Peek(ctx context.Context, queueName string, input PeekInput) (result QueueMessagesListResponse, err error) {
+
+	if queueName == "" {
+		return result, fmt.Errorf("`queueName` cannot be an empty string")
+	}
+
+	if strings.ToLower(queueName) != queueName {
+		return result, fmt.Errorf("`queueName` must be a lower-cased string")
+	}
+
+	if input.NumberOfMessages < 1 || input.NumberOfMessages > 32 {
+		return result, fmt.Errorf("`input.NumberOfMessages` must be between 1 and 32")
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		OptionsObject: peekOptions{
+			numberOfMessages: input.NumberOfMessages,
+		},
+		Path: fmt.Sprintf("/%s/messages", queueName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			err = resp.Unmarshal(&result)
+			if err != nil {
+				err = fmt.Errorf("unmarshalling response: %+v", err)
+				return
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type peekOptions struct {
+	numberOfMessages int
+}
+
+func (p peekOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (p peekOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (p peekOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("numofmessages", strconv.Itoa(p.numberOfMessages))
+	out.Append("peekonly", "true")
+	return out
+}

--- a/storage/2026-02-06/queue/messages/put.go
+++ b/storage/2026-02-06/queue/messages/put.go
@@ -1,0 +1,120 @@
+package messages
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type PutInput struct {
+	// A message must be in a format that can be included in an XML request with UTF-8 encoding.
+	// The encoded message can be up to 64 KB in size.
+	Message string
+
+	// The maximum time-to-live can be any positive number,
+	// as well as -1 indicating that the message does not expire.
+	// If this parameter is omitted, the default time-to-live is 7 days.
+	MessageTtl *int
+
+	// Specifies the new visibility timeout value, in seconds, relative to server time.
+	// The new value must be larger than or equal to 0, and cannot be larger than 7 days.
+	// The visibility timeout of a message cannot be set to a value later than the expiry time.
+	// visibilitytimeout should be set to a value smaller than the time-to-live value.
+	// If not specified, the default value is 0.
+	VisibilityTimeout *int
+}
+
+// Put adds a new message to the back of the message queue
+func (c Client) Put(ctx context.Context, queueName string, input PutInput) (result QueueMessagesListResponse, err error) {
+	if queueName == "" {
+		return result, fmt.Errorf("`queueName` cannot be an empty string")
+	}
+
+	if strings.ToLower(queueName) != queueName {
+		return result, fmt.Errorf("`queueName` must be a lower-cased string")
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPost,
+		OptionsObject: putOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/messages", queueName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	marshalledMsg, err := xml.Marshal(QueueMessage{
+		MessageText: input.Message,
+	})
+	if err != nil {
+		return result, fmt.Errorf("marshalling request: %+v", err)
+	}
+
+	body := xml.Header + string(marshalledMsg)
+	req.Body = io.NopCloser(bytes.NewReader([]byte(body)))
+	req.ContentLength = int64(len(body))
+	req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			err = resp.Unmarshal(&result)
+			if err != nil {
+				err = fmt.Errorf("unmarshalling response: %+v", err)
+				return
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type putOptions struct {
+	input PutInput
+}
+
+func (p putOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (p putOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (p putOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+
+	if p.input.MessageTtl != nil {
+		out.Append("messagettl", strconv.Itoa(*p.input.MessageTtl))
+	}
+
+	if p.input.VisibilityTimeout != nil {
+		out.Append("visibilitytimeout", strconv.Itoa(*p.input.VisibilityTimeout))
+	}
+
+	return out
+}

--- a/storage/2026-02-06/queue/messages/update.go
+++ b/storage/2026-02-06/queue/messages/update.go
@@ -1,0 +1,109 @@
+package messages
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type UpdateInput struct {
+	// A message must be in a format that can be included in an XML request with UTF-8 encoding.
+	// The encoded message can be up to 64 KB in size.
+	Message string
+
+	// Specifies the valid pop receipt value required to modify this message.
+	PopReceipt string
+
+	// Specifies the new visibility timeout value, in seconds, relative to server time.
+	// The new value must be larger than or equal to 0, and cannot be larger than 7 days.
+	// The visibility timeout of a message cannot be set to a value later than the expiry time.
+	// A message can be updated until it has been deleted or has expired.
+	VisibilityTimeout int
+}
+
+type UpdateResponse struct {
+	HttpResponse *http.Response
+}
+
+// Update updates an existing message based on it's Pop Receipt
+func (c Client) Update(ctx context.Context, queueName string, messageID string, input UpdateInput) (result UpdateResponse, err error) {
+
+	if queueName == "" {
+		return result, fmt.Errorf("`queueName` cannot be an empty string")
+	}
+	if strings.ToLower(queueName) != queueName {
+		return result, fmt.Errorf("`queueName` must be a lower-cased string")
+	}
+	if input.PopReceipt == "" {
+		return result, fmt.Errorf("`input.PopReceipt` cannot be an empty string")
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: updateOptions{
+			input: input,
+		},
+		Path: fmt.Sprintf("/%s/messages/%s", queueName, messageID),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	marshalledMsg, err := xml.Marshal(QueueMessage{
+		MessageText: input.Message,
+	})
+	if err != nil {
+		return result, fmt.Errorf("marshalling request: %+v", err)
+	}
+
+	body := xml.Header + string(marshalledMsg)
+	req.Body = io.NopCloser(bytes.NewReader([]byte(body)))
+	req.ContentLength = int64(len(body))
+	req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type updateOptions struct {
+	input UpdateInput
+}
+
+func (u updateOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (u updateOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (u updateOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("visibilitytimeout", strconv.Itoa(u.input.VisibilityTimeout))
+	out.Append("popreceipt", u.input.PopReceipt)
+	return out
+}

--- a/storage/2026-02-06/queue/messages/version.go
+++ b/storage/2026-02-06/queue/messages/version.go
@@ -1,0 +1,5 @@
+package messages
+
+// APIVersion is the version of the API used for all Storage API Operations
+const apiVersion = "2026-02-06"
+const componentName = "queue/messages"

--- a/storage/2026-02-06/queue/queues/README.md
+++ b/storage/2026-02-06/queue/queues/README.md
@@ -1,0 +1,53 @@
+## Queue Storage Queues SDK for API version 2026-02-06
+
+This package allows you to interact with the Queues Queue Storage API
+
+### Supported Authorizers
+
+* Azure Active Directory (for the Resource Endpoint `https://storage.azure.com`)
+* SharedKeyLite (Blob, File & Queue)
+
+### Example Usage
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/queue/queues"
+)
+
+func Example() error {
+	accountName := "storageaccount1"
+    storageAccountKey := "ABC123...."
+    queueName := "myqueue"
+	domainSuffix := "core.windows.net"
+
+	auth, err := auth.NewSharedKeyAuthorizer(accountName, storageAccountKey, auth.SharedKey)
+	if err != nil {
+		return fmt.Errorf("building SharedKey authorizer: %+v", err)
+	}
+	
+    queuesClient, err := queues.NewWithBaseUri(fmt.Sprintf("https://%s.queue.%s", accountName, domainSuffix))
+	if err != nil {
+		return fmt.Errorf("building client for environment: %+v", err)
+	}
+    queuesClient.Client.SetAuthorizer(auth)
+    
+    ctx := context.TODO()
+    metadata := map[string]string{
+    	"hello": "world",
+    }
+	input := queues.CreateInput{
+		Metadata: metadata,
+    }
+    if _, err := queuesClient.Create(ctx, queueName, input); err != nil {
+        return fmt.Errorf("Error creating Queue: %s", err)
+    }
+    
+    return nil 
+}
+```

--- a/storage/2026-02-06/queue/queues/api.go
+++ b/storage/2026-02-06/queue/queues/api.go
@@ -1,0 +1,15 @@
+package queues
+
+import (
+	"context"
+)
+
+type StorageQueue interface {
+	Delete(ctx context.Context, queueName string) (DeleteResponse, error)
+	GetMetaData(ctx context.Context, queueName string) (GetMetaDataResponse, error)
+	SetMetaData(ctx context.Context, queueName string, input SetMetaDataInput) (SetMetaDataResponse, error)
+	Create(ctx context.Context, queueName string, input CreateInput) (CreateResponse, error)
+	GetResourceManagerResourceID(subscriptionID, resourceGroup, accountName, queueName string) string
+	SetServiceProperties(ctx context.Context, input SetStorageServicePropertiesInput) (SetStorageServicePropertiesResponse, error)
+	GetServiceProperties(ctx context.Context) (GetStorageServicePropertiesResponse, error)
+}

--- a/storage/2026-02-06/queue/queues/client.go
+++ b/storage/2026-02-06/queue/queues/client.go
@@ -1,0 +1,24 @@
+package queues
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/dataplane/storage"
+)
+
+// Client is the base client for Queue Storage Shares.
+
+// Client is the base client for Messages.
+type Client struct {
+	Client *storage.Client
+}
+
+func NewWithBaseUri(baseUri string) (*Client, error) {
+	baseClient, err := storage.NewStorageClient(baseUri, componentName, apiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("building base client: %+v", err)
+	}
+	return &Client{
+		Client: baseClient,
+	}, nil
+}

--- a/storage/2026-02-06/queue/queues/create.go
+++ b/storage/2026-02-06/queue/queues/create.go
@@ -1,0 +1,87 @@
+package queues
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type CreateInput struct {
+	MetaData map[string]string
+}
+
+type CreateResponse struct {
+	HttpResponse *http.Response
+}
+
+// Create creates the specified Queue within the specified Storage Account
+func (c Client) Create(ctx context.Context, queueName string, input CreateInput) (result CreateResponse, err error) {
+
+	if queueName == "" {
+		return result, fmt.Errorf("`queueName` cannot be an empty string")
+	}
+
+	if strings.ToLower(queueName) != queueName {
+		return result, fmt.Errorf("`queueName` must be a lower-cased string")
+	}
+
+	if err := metadata.Validate(input.MetaData); err != nil {
+		return result, fmt.Errorf("`metadata` is not valid: %s", err)
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusCreated,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: createOptions{
+			metadata: input.MetaData,
+		},
+		Path: fmt.Sprintf("/%s", queueName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type createOptions struct {
+	metadata map[string]string
+}
+
+func (c createOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+
+	if len(c.metadata) > 0 {
+		headers.Merge(metadata.SetMetaDataHeaders(c.metadata))
+	}
+	return headers
+}
+
+func (c createOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (c createOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/queue/queues/delete.go
+++ b/storage/2026-02-06/queue/queues/delete.go
@@ -1,0 +1,54 @@
+package queues
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+)
+
+type DeleteResponse struct {
+	HttpResponse *http.Response
+}
+
+// Delete deletes the specified Queue within the specified Storage Account
+func (c Client) Delete(ctx context.Context, queueName string) (result DeleteResponse, err error) {
+
+	if queueName == "" {
+		return result, fmt.Errorf("`queueName` cannot be an empty string")
+	}
+
+	if strings.ToLower(queueName) != queueName {
+		return result, fmt.Errorf("`queueName` must be a lower-cased string")
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+		},
+		HttpMethod:    http.MethodDelete,
+		OptionsObject: nil,
+		Path:          fmt.Sprintf("/%s", queueName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}

--- a/storage/2026-02-06/queue/queues/lifecycle_test.go
+++ b/storage/2026-02-06/queue/queues/lifecycle_test.go
@@ -1,0 +1,261 @@
+package queues
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+var _ StorageQueue = Client{}
+
+func TestQueuesLifecycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	queueName := fmt.Sprintf("queue-%d", testhelpers.RandomInt())
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+	queuesClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.%s.%s", accountName, "queue", *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err := client.PrepareWithSharedKeyAuth(queuesClient.Client, testData, auth.SharedKey); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	// first let's test an empty container
+	_, err = queuesClient.Create(ctx, queueName, CreateInput{MetaData: map[string]string{}})
+	if err != nil {
+		t.Fatal(fmt.Errorf("error creating: %s", err))
+	}
+
+	// then let's retrieve it to ensure there's no metadata..
+	resp, err := queuesClient.GetMetaData(ctx, queueName)
+	if err != nil {
+		t.Fatalf("Error retrieving MetaData: %s", err)
+	}
+	if len(resp.MetaData) != 0 {
+		t.Fatalf("Expected no MetaData but got: %s", err)
+	}
+
+	// then let's add some..
+	updatedMetaData := map[string]string{
+		"band":  "panic",
+		"boots": "the-overpass",
+	}
+	_, err = queuesClient.SetMetaData(ctx, queueName, SetMetaDataInput{MetaData: updatedMetaData})
+	if err != nil {
+		t.Fatalf("Error setting MetaData: %s", err)
+	}
+
+	resp, err = queuesClient.GetMetaData(ctx, queueName)
+	if err != nil {
+		t.Fatalf("Error re-retrieving MetaData: %s", err)
+	}
+
+	if len(resp.MetaData) != 2 {
+		t.Fatalf("Expected metadata to have 2 items but got: %s", resp.MetaData)
+	}
+	if resp.MetaData["band"] != "panic" {
+		t.Fatalf("Expected `band` to be `panic` but got: %s", resp.MetaData["band"])
+	}
+	if resp.MetaData["boots"] != "the-overpass" {
+		t.Fatalf("Expected `boots` to be `the-overpass` but got: %s", resp.MetaData["boots"])
+	}
+
+	// and woo let's remove it again
+	_, err = queuesClient.SetMetaData(ctx, queueName, SetMetaDataInput{MetaData: map[string]string{}})
+	if err != nil {
+		t.Fatalf("Error setting MetaData: %s", err)
+	}
+
+	resp, err = queuesClient.GetMetaData(ctx, queueName)
+	if err != nil {
+		t.Fatalf("Error retrieving MetaData: %s", err)
+	}
+	if len(resp.MetaData) != 0 {
+		t.Fatalf("Expected no MetaData but got: %s", err)
+	}
+
+	// set some properties
+	props := StorageServiceProperties{
+		Logging: &LoggingConfig{
+			Version: "1.0",
+			Delete:  true,
+			Read:    true,
+			Write:   true,
+			RetentionPolicy: RetentionPolicy{
+				Enabled: true,
+				Days:    7,
+			},
+		},
+		Cors: &Cors{
+			CorsRule: []CorsRule{
+				CorsRule{
+					AllowedMethods:  "GET,PUT",
+					AllowedOrigins:  "http://www.example.com",
+					ExposedHeaders:  "x-tempo-*",
+					AllowedHeaders:  "x-tempo-*",
+					MaxAgeInSeconds: 500,
+				},
+				CorsRule{
+					AllowedMethods:  "POST",
+					AllowedOrigins:  "http://www.test.com",
+					ExposedHeaders:  "*",
+					AllowedHeaders:  "x-method-*",
+					MaxAgeInSeconds: 200,
+				},
+			},
+		},
+		HourMetrics: &MetricsConfig{
+			Version: "1.0",
+			Enabled: false,
+			RetentionPolicy: RetentionPolicy{
+				Enabled: true,
+				Days:    7,
+			},
+		},
+		MinuteMetrics: &MetricsConfig{
+			Version: "1.0",
+			Enabled: false,
+			RetentionPolicy: RetentionPolicy{
+				Enabled: true,
+				Days:    7,
+			},
+		},
+	}
+	_, err = queuesClient.SetServiceProperties(ctx, SetStorageServicePropertiesInput{Properties: props})
+	if err != nil {
+		t.Fatalf("SetServiceProperties failed: %s", err)
+	}
+
+	properties, err := queuesClient.GetServiceProperties(ctx)
+	if err != nil {
+		t.Fatalf("GetServiceProperties failed: %s", err)
+	}
+
+	if len(properties.Cors.CorsRule) > 1 {
+		if properties.Cors.CorsRule[0].AllowedMethods != "GET,PUT" {
+			t.Fatalf("CORS Methods weren't set!")
+		}
+		if properties.Cors.CorsRule[1].AllowedMethods != "POST" {
+			t.Fatalf("CORS Methods weren't set!")
+		}
+	} else {
+		t.Fatalf("CORS Methods weren't set!")
+	}
+
+	if properties.HourMetrics.Enabled {
+		t.Fatalf("HourMetrics were enabled when they shouldn't be!")
+	}
+
+	if properties.MinuteMetrics.Enabled {
+		t.Fatalf("MinuteMetrics were enabled when they shouldn't be!")
+	}
+
+	if !properties.Logging.Write {
+		t.Fatalf("Logging Write's was not enabled when they should be!")
+	}
+
+	includeAPIS := true
+	// set some properties
+	props2 := StorageServiceProperties{
+		Logging: &LoggingConfig{
+			Version: "1.0",
+			Delete:  true,
+			Read:    true,
+			Write:   true,
+			RetentionPolicy: RetentionPolicy{
+				Enabled: true,
+				Days:    7,
+			},
+		},
+		Cors: &Cors{
+			CorsRule: []CorsRule{
+				CorsRule{
+					AllowedMethods:  "PUT",
+					AllowedOrigins:  "http://www.example.com",
+					ExposedHeaders:  "x-tempo-*",
+					AllowedHeaders:  "x-tempo-*",
+					MaxAgeInSeconds: 500,
+				},
+			},
+		},
+		HourMetrics: &MetricsConfig{
+			Version: "1.0",
+			Enabled: true,
+			RetentionPolicy: RetentionPolicy{
+				Enabled: true,
+				Days:    7,
+			},
+			IncludeAPIs: &includeAPIS,
+		},
+		MinuteMetrics: &MetricsConfig{
+			Version: "1.0",
+			Enabled: false,
+			RetentionPolicy: RetentionPolicy{
+				Enabled: true,
+				Days:    7,
+			},
+		},
+	}
+
+	_, err = queuesClient.SetServiceProperties(ctx, SetStorageServicePropertiesInput{Properties: props2})
+	if err != nil {
+		t.Fatalf("SetServiceProperties failed: %s", err)
+	}
+
+	properties, err = queuesClient.GetServiceProperties(ctx)
+	if err != nil {
+		t.Fatalf("GetServiceProperties failed: %s", err)
+	}
+
+	if len(properties.Cors.CorsRule) == 1 {
+		if properties.Cors.CorsRule[0].AllowedMethods != "PUT" {
+			t.Fatalf("CORS Methods weren't set!")
+		}
+	} else {
+		t.Fatalf("CORS Methods weren't set!")
+	}
+
+	if !properties.HourMetrics.Enabled {
+		t.Fatalf("HourMetrics were enabled when they shouldn't be!")
+	}
+
+	if properties.MinuteMetrics.Enabled {
+		t.Fatalf("MinuteMetrics were enabled when they shouldn't be!")
+	}
+
+	if !properties.Logging.Write {
+		t.Fatalf("Logging Write's was not enabled when they should be!")
+	}
+
+	log.Printf("[DEBUG] Deleting..")
+	_, err = queuesClient.Delete(ctx, queueName)
+	if err != nil {
+		t.Fatal(fmt.Errorf("error deleting: %s", err))
+	}
+}

--- a/storage/2026-02-06/queue/queues/metadata_get.go
+++ b/storage/2026-02-06/queue/queues/metadata_get.go
@@ -1,0 +1,86 @@
+package queues
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type GetMetaDataResponse struct {
+	HttpResponse *http.Response
+
+	MetaData map[string]string
+}
+
+// GetMetaData returns the metadata for this Queue
+func (c Client) GetMetaData(ctx context.Context, queueName string) (result GetMetaDataResponse, err error) {
+
+	if queueName == "" {
+		return result, fmt.Errorf("`queueName` cannot be an empty string")
+	}
+
+	if strings.ToLower(queueName) != queueName {
+		return result, fmt.Errorf("`queueName` must be a lower-cased string")
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: getMetaDataOptions{},
+		Path:          fmt.Sprintf("/%s", queueName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			if resp.Header != nil {
+				result.MetaData = metadata.ParseFromHeaders(resp.Header)
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	if result.HttpResponse != nil {
+		if result.HttpResponse.Header != nil {
+			result.MetaData = metadata.ParseFromHeaders(result.HttpResponse.Header)
+		}
+	}
+
+	return
+}
+
+type getMetaDataOptions struct{}
+
+func (g getMetaDataOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (g getMetaDataOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (g getMetaDataOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "metadata")
+	return out
+}

--- a/storage/2026-02-06/queue/queues/metadata_set.go
+++ b/storage/2026-02-06/queue/queues/metadata_set.go
@@ -1,0 +1,86 @@
+package queues
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+	"github.com/jackofallops/giovanni/storage/internal/metadata"
+)
+
+type SetMetaDataResponse struct {
+	HttpResponse *http.Response
+}
+
+type SetMetaDataInput struct {
+	MetaData map[string]string
+}
+
+// SetMetaData returns the metadata for this Queue
+func (c Client) SetMetaData(ctx context.Context, queueName string, input SetMetaDataInput) (result SetMetaDataResponse, err error) {
+
+	if queueName == "" {
+		return result, fmt.Errorf("`queueName` cannot be an empty string")
+	}
+
+	if strings.ToLower(queueName) != queueName {
+		return result, fmt.Errorf("`queueName` must be a lower-cased string")
+	}
+
+	if err := metadata.Validate(input.MetaData); err != nil {
+		return result, fmt.Errorf("`metadata` is not valid: %+v", err)
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodPut,
+		OptionsObject: setMetaDataOptions{
+			metadata: input.MetaData,
+		},
+		Path: fmt.Sprintf("/%s", queueName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type setMetaDataOptions struct {
+	metadata map[string]string
+}
+
+func (s setMetaDataOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Merge(metadata.SetMetaDataHeaders(s.metadata))
+	return headers
+}
+
+func (s setMetaDataOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (s setMetaDataOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "metadata")
+	return out
+}

--- a/storage/2026-02-06/queue/queues/models.go
+++ b/storage/2026-02-06/queue/queues/models.go
@@ -1,0 +1,42 @@
+package queues
+
+type StorageServiceProperties struct {
+	Logging       *LoggingConfig `xml:"Logging,omitempty"`
+	HourMetrics   *MetricsConfig `xml:"HourMetrics,omitempty"`
+	MinuteMetrics *MetricsConfig `xml:"MinuteMetrics,omitempty"`
+	Cors          *Cors          `xml:"Cors,omitempty"`
+}
+
+type LoggingConfig struct {
+	Version         string          `xml:"Version"`
+	Delete          bool            `xml:"Delete"`
+	Read            bool            `xml:"Read"`
+	Write           bool            `xml:"Write"`
+	RetentionPolicy RetentionPolicy `xml:"RetentionPolicy"`
+}
+
+type MetricsConfig struct {
+	Version         string          `xml:"Version"`
+	Enabled         bool            `xml:"Enabled"`
+	RetentionPolicy RetentionPolicy `xml:"RetentionPolicy"`
+
+	// Element IncludeAPIs is only expected when Metrics is enabled
+	IncludeAPIs *bool `xml:"IncludeAPIs,omitempty"`
+}
+
+type RetentionPolicy struct {
+	Enabled bool `xml:"Enabled"`
+	Days    int  `xml:"Days,omitempty"`
+}
+
+type Cors struct {
+	CorsRule []CorsRule `xml:"CorsRule"`
+}
+
+type CorsRule struct {
+	AllowedOrigins  string `xml:"AllowedOrigins"`
+	AllowedMethods  string `xml:"AllowedMethods"`
+	AllowedHeaders  string `xml:"AllowedHeaders"`
+	ExposedHeaders  string `xml:"ExposedHeaders"`
+	MaxAgeInSeconds int    `xml:"MaxAgeInSeconds"`
+}

--- a/storage/2026-02-06/queue/queues/properties_get.go
+++ b/storage/2026-02-06/queue/queues/properties_get.go
@@ -1,0 +1,72 @@
+package queues
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type GetStorageServicePropertiesResponse struct {
+	StorageServiceProperties
+	HttpResponse *http.Response
+}
+
+// GetServiceProperties gets the properties for this queue
+func (c Client) GetServiceProperties(ctx context.Context) (result GetStorageServicePropertiesResponse, err error) {
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: getStorageServicePropertiesOptions{},
+		Path:          "/",
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			err = resp.Unmarshal(&result)
+			if err != nil {
+				err = fmt.Errorf("unmarshalling response: %+v", err)
+				return
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type getStorageServicePropertiesOptions struct{}
+
+func (g getStorageServicePropertiesOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (g getStorageServicePropertiesOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (g getStorageServicePropertiesOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "properties")
+	out.Append("restype", "service")
+	return out
+}

--- a/storage/2026-02-06/queue/queues/properties_set.go
+++ b/storage/2026-02-06/queue/queues/properties_set.go
@@ -1,0 +1,80 @@
+package queues
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type SetStorageServicePropertiesResponse struct {
+	HttpResponse *http.Response
+}
+
+type SetStorageServicePropertiesInput struct {
+	Properties StorageServiceProperties
+}
+
+// SetServiceProperties sets the properties for this queue
+func (c Client) SetServiceProperties(ctx context.Context, input SetStorageServicePropertiesInput) (result SetStorageServicePropertiesResponse, err error) {
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusAccepted,
+		},
+		HttpMethod:    http.MethodPut,
+		OptionsObject: setStorageServicePropertiesOptions{},
+		Path:          "/",
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	marshalledProps, err := xml.Marshal(&input.Properties)
+	if err != nil {
+		return result, fmt.Errorf("marshalling request: %+v", err)
+	}
+	body := xml.Header + string(marshalledProps)
+	req.Body = io.NopCloser(bytes.NewReader([]byte(body)))
+	req.ContentLength = int64(len(body))
+	req.Header.Set("Content-Length", strconv.Itoa(len(body)))
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type setStorageServicePropertiesOptions struct{}
+
+func (s setStorageServicePropertiesOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (s setStorageServicePropertiesOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (s setStorageServicePropertiesOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("restype", "service")
+	out.Append("comp", "properties")
+	return out
+}

--- a/storage/2026-02-06/queue/queues/resource_id.go
+++ b/storage/2026-02-06/queue/queues/resource_id.go
@@ -1,0 +1,81 @@
+package queues
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+// GetResourceManagerResourceID returns the Resource Manager ID for the given Queue
+// This can be useful when, for example, you're using this as a unique identifier
+func (c Client) GetResourceManagerResourceID(subscriptionID, resourceGroup, accountName, queueName string) string {
+	fmtStr := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/queueServices/default/queues/%s"
+	return fmt.Sprintf(fmtStr, subscriptionID, resourceGroup, accountName, queueName)
+}
+
+// TODO: update this to implement `resourceids.ResourceId` once
+// https://github.com/hashicorp/go-azure-helpers/issues/187 is fixed
+var _ resourceids.Id = QueueId{}
+
+type QueueId struct {
+	// AccountId specifies the ID of the Storage Account where this Queue exists.
+	AccountId accounts.AccountId
+
+	// QueueName specifies the name of this Queue.
+	QueueName string
+}
+
+func NewQueueID(accountId accounts.AccountId, queueName string) QueueId {
+	return QueueId{
+		AccountId: accountId,
+		QueueName: queueName,
+	}
+}
+
+func (b QueueId) ID() string {
+	return fmt.Sprintf("%s/%s", b.AccountId.ID(), b.QueueName)
+}
+
+func (b QueueId) String() string {
+	components := []string{
+		fmt.Sprintf("Account %q", b.AccountId.String()),
+	}
+	return fmt.Sprintf("Queue %q (%s)", b.QueueName, strings.Join(components, " / "))
+}
+
+// ParseQueueID parses `input` into a Queue ID using a known `domainSuffix`
+func ParseQueueID(input, domainSuffix string) (*QueueId, error) {
+	// example: https://foo.queue.core.windows.net/Bar
+	if input == "" {
+		return nil, fmt.Errorf("`input` was empty")
+	}
+
+	account, err := accounts.ParseAccountID(input, domainSuffix)
+	if err != nil {
+		return nil, fmt.Errorf("parsing account %q: %+v", input, err)
+	}
+
+	if account.SubDomainType != accounts.QueueSubDomainType {
+		return nil, fmt.Errorf("expected the subdomain type to be %q but got %q", string(accounts.QueueSubDomainType), string(account.SubDomainType))
+	}
+
+	uri, err := url.Parse(input)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q as a uri: %+v", input, err)
+	}
+
+	path := strings.TrimPrefix(uri.Path, "/")
+	segments := strings.Split(path, "/")
+	if len(segments) != 1 {
+		return nil, fmt.Errorf("expected the path to contain 1 segment but got %d", len(segments))
+	}
+
+	queueName := strings.TrimPrefix(uri.Path, "/")
+	return &QueueId{
+		AccountId: *account,
+		QueueName: queueName,
+	}, nil
+}

--- a/storage/2026-02-06/queue/queues/resource_id_test.go
+++ b/storage/2026-02-06/queue/queues/resource_id_test.go
@@ -1,0 +1,162 @@
+package queues
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+func TestGetResourceManagerResourceID(t *testing.T) {
+	actual := Client{}.GetResourceManagerResourceID("11112222-3333-4444-5555-666677778888", "group1", "account1", "queue1")
+	expected := "/subscriptions/11112222-3333-4444-5555-666677778888/resourceGroups/group1/providers/Microsoft.Storage/storageAccounts/account1/queueServices/default/queues/queue1"
+	if actual != expected {
+		t.Fatalf("Expected the Resource Manager Resource ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseQueueIDStandard(t *testing.T) {
+	input := "https://example1.queue.core.windows.net/queue1"
+	expected := QueueId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.QueueSubDomainType,
+			DomainSuffix:  "core.windows.net",
+		},
+		QueueName: "queue1",
+	}
+	actual, err := ParseQueueID(input, "core.windows.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if actual.QueueName != expected.QueueName {
+		t.Fatalf("expected QueueName to be %q but got %q", expected.QueueName, actual.QueueName)
+	}
+}
+
+func TestParseQueueIDInADNSZone(t *testing.T) {
+	input := "https://example1.zone1.queue.storage.azure.net/queue1"
+	expected := QueueId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.QueueSubDomainType,
+			DomainSuffix:  "storage.azure.net",
+			ZoneName:      pointer.To("zone1"),
+		},
+		QueueName: "queue1",
+	}
+	actual, err := ParseQueueID(input, "storage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if pointer.From(actual.AccountId.ZoneName) != pointer.From(expected.AccountId.ZoneName) {
+		t.Fatalf("expected ZoneName to be %q but got %q", pointer.From(expected.AccountId.ZoneName), pointer.From(actual.AccountId.ZoneName))
+	}
+	if actual.QueueName != expected.QueueName {
+		t.Fatalf("expected QueueName to be %q but got %q", expected.QueueName, actual.QueueName)
+	}
+}
+
+func TestParseQueueIDInAnEdgeZone(t *testing.T) {
+	input := "https://example1.queue.zone1.edgestorage.azure.net/queue1"
+	expected := QueueId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.QueueSubDomainType,
+			DomainSuffix:  "edgestorage.azure.net",
+			ZoneName:      pointer.To("zone1"),
+			IsEdgeZone:    true,
+		},
+		QueueName: "queue1",
+	}
+	actual, err := ParseQueueID(input, "edgestorage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if pointer.From(actual.AccountId.ZoneName) != pointer.From(expected.AccountId.ZoneName) {
+		t.Fatalf("expected ZoneName to be %q but got %q", pointer.From(expected.AccountId.ZoneName), pointer.From(actual.AccountId.ZoneName))
+	}
+	if !actual.AccountId.IsEdgeZone {
+		t.Fatalf("expected the Account to be in an Edge Zone but it wasn't")
+	}
+	if actual.QueueName != expected.QueueName {
+		t.Fatalf("expected QueueName to be %q but got %q", expected.QueueName, actual.QueueName)
+	}
+}
+
+func TestFormatQueueIDStandard(t *testing.T) {
+	actual := QueueId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.QueueSubDomainType,
+			DomainSuffix:  "core.windows.net",
+			IsEdgeZone:    false,
+		},
+		QueueName: "queue1",
+	}.ID()
+	expected := "https://example1.queue.core.windows.net/queue1"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatQueueIDInDNSZone(t *testing.T) {
+	actual := QueueId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			ZoneName:      pointer.To("zone2"),
+			SubDomainType: accounts.QueueSubDomainType,
+			DomainSuffix:  "storage.azure.net",
+			IsEdgeZone:    false,
+		},
+		QueueName: "queue1",
+	}.ID()
+	expected := "https://example1.zone2.queue.storage.azure.net/queue1"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatQueueIDInEdgeZone(t *testing.T) {
+	actual := QueueId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			ZoneName:      pointer.To("zone2"),
+			SubDomainType: accounts.QueueSubDomainType,
+			DomainSuffix:  "edgestorage.azure.net",
+			IsEdgeZone:    true,
+		},
+		QueueName: "queue1",
+	}.ID()
+	expected := "https://example1.queue.zone2.edgestorage.azure.net/queue1"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}

--- a/storage/2026-02-06/queue/queues/version.go
+++ b/storage/2026-02-06/queue/queues/version.go
@@ -1,0 +1,5 @@
+package queues
+
+// APIVersion is the version of the API used for all Storage API Operations
+const apiVersion = "2026-02-06"
+const componentName = "queue/queues"

--- a/storage/2026-02-06/table/entities/README.md
+++ b/storage/2026-02-06/table/entities/README.md
@@ -1,0 +1,55 @@
+## Table Storage Entities SDK for API version 2026-02-06
+
+This package allows you to interact with the Entities Table Storage API
+
+### Supported Authorizers
+
+* SharedKeyLite (Table)
+
+### Example Usage
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/table/entities"
+)
+
+func Example() error {
+	accountName := "storageaccount1"
+    storageAccountKey := "ABC123...."
+    tableName := "mytable"
+	domainSuffix := "core.windows.net"
+
+	auth, err := auth.NewSharedKeyAuthorizer(accountName, storageAccountKey, auth.SharedKeyTable)
+	if err != nil {
+		return fmt.Errorf("building SharedKey authorizer: %+v", err)
+	}
+	
+    entitiesClient, err := entities.NewWithBaseUri(fmt.Sprintf("https://%s.table.%s", accountName, domainSuffix))
+	if err != nil {
+		return fmt.Errorf("building client for environment: %+v", err)
+	}
+	entitiesClient.Client.SetAuthorizer(auth)
+    
+    ctx := context.TODO()
+    input := entities.InsertEntityInput{
+    	PartitionKey: "abc",
+    	RowKey: "123",
+    	MetaDataLevel: entities.NoMetaData,
+    	Entity: map[string]interface{}{
+    	    "title": "Don't Kill My Vibe",
+    	    "artist": "Sigrid",
+    	},
+    }
+    if _, err := entitiesClient.Insert(ctx, tableName, input); err != nil {
+        return fmt.Errorf("Error creating Entity: %s", err)
+    }
+    
+    return nil 
+}
+```

--- a/storage/2026-02-06/table/entities/api.go
+++ b/storage/2026-02-06/table/entities/api.go
@@ -1,0 +1,14 @@
+package entities
+
+import (
+	"context"
+)
+
+type StorageTableEntity interface {
+	Delete(ctx context.Context, tableName string, input DeleteEntityInput) (resp DeleteEntityResponse, err error)
+	Insert(ctx context.Context, tableName string, input InsertEntityInput) (resp InsertResponse, err error)
+	InsertOrReplace(ctx context.Context, tableName string, input InsertOrReplaceEntityInput) (resp InsertOrReplaceResponse, err error)
+	InsertOrMerge(ctx context.Context, tableName string, input InsertOrMergeEntityInput) (resp InsertOrMergeResponse, err error)
+	Query(ctx context.Context, tableName string, input QueryEntitiesInput) (resp QueryEntitiesResponse, err error)
+	Get(ctx context.Context, tableName string, input GetEntityInput) (resp GetEntityResponse, err error)
+}

--- a/storage/2026-02-06/table/entities/client.go
+++ b/storage/2026-02-06/table/entities/client.go
@@ -1,0 +1,23 @@
+package entities
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/dataplane/storage"
+)
+
+// Client is the base client for Table Storage Shares.
+type Client struct {
+	Client *storage.Client
+}
+
+func NewWithBaseUri(baseUri string) (*Client, error) {
+	baseClient, err := storage.NewStorageClient(baseUri, componentName, apiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("building base client: %+v", err)
+	}
+
+	return &Client{
+		Client: baseClient,
+	}, nil
+}

--- a/storage/2026-02-06/table/entities/delete.go
+++ b/storage/2026-02-06/table/entities/delete.go
@@ -1,0 +1,84 @@
+package entities
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type DeleteEntityInput struct {
+	// When inserting an entity into a table, you must specify values for the PartitionKey and RowKey system properties.
+	// Together, these properties form the primary key and must be unique within the table.
+	// Both the PartitionKey and RowKey values must be string values; each key value may be up to 64 KB in size.
+	// If you are using an integer value for the key value, you should convert the integer to a fixed-width string,
+	// because they are canonically sorted. For example, you should convert the value 1 to 0000001 to ensure proper sorting.
+	RowKey       string
+	PartitionKey string
+}
+
+type DeleteEntityResponse struct {
+	HttpResponse *http.Response
+}
+
+// Delete deletes an existing entity in a table.
+func (c Client) Delete(ctx context.Context, tableName string, input DeleteEntityInput) (result DeleteEntityResponse, err error) {
+
+	if tableName == "" {
+		return result, fmt.Errorf("`tableName` cannot be an empty string")
+	}
+
+	if input.PartitionKey == "" {
+		return result, fmt.Errorf("`input.PartitionKey` cannot be an empty string")
+	}
+
+	if input.RowKey == "" {
+		return result, fmt.Errorf("`input.RowKey` cannot be an empty string")
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+		},
+		HttpMethod:    http.MethodDelete,
+		OptionsObject: deleteEntitiesOptions{},
+		Path:          fmt.Sprintf("/%s(PartitionKey='%s', RowKey='%s')", tableName, input.PartitionKey, input.RowKey),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+	return
+}
+
+type deleteEntitiesOptions struct{}
+
+func (d deleteEntitiesOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("Accept", "application/json")
+	headers.Append("If-Match", "*")
+	return headers
+}
+
+func (d deleteEntitiesOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (d deleteEntitiesOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/table/entities/get.go
+++ b/storage/2026-02-06/table/entities/get.go
@@ -1,0 +1,96 @@
+package entities
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type GetEntityInput struct {
+	PartitionKey string
+	RowKey       string
+
+	// The Level of MetaData which should be returned
+	MetaDataLevel MetaDataLevel
+}
+
+type GetEntityResponse struct {
+	HttpResponse *http.Response
+
+	Entity map[string]interface{}
+}
+
+// Get queries entities in a table and includes the $filter and $select options.
+func (c Client) Get(ctx context.Context, tableName string, input GetEntityInput) (result GetEntityResponse, err error) {
+	if tableName == "" {
+		return result, fmt.Errorf("`tableName` cannot be an empty string")
+	}
+
+	if input.PartitionKey == "" {
+		return result, fmt.Errorf("`input.PartitionKey` cannot be an empty string")
+	}
+
+	if input.RowKey == "" {
+		return result, fmt.Errorf("`input.RowKey` cannot be an empty string")
+	}
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		OptionsObject: getEntitiesOptions{
+			MetaDataLevel: input.MetaDataLevel,
+		},
+		Path: fmt.Sprintf("/%s(PartitionKey='%s', RowKey='%s')", tableName, input.PartitionKey, input.RowKey),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			err = resp.Unmarshal(&result.Entity)
+			if err != nil {
+				err = fmt.Errorf("unmarshalling response: %+v", err)
+				return
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type getEntitiesOptions struct {
+	MetaDataLevel MetaDataLevel
+}
+
+func (g getEntitiesOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("Accept", fmt.Sprintf("application/json;odata=%s", g.MetaDataLevel))
+	headers.Append("DataServiceVersion", "3.0;NetFx")
+	headers.Append("MaxDataServiceVersion", "3.0;NetFx")
+	return headers
+}
+
+func (g getEntitiesOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (g getEntitiesOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/table/entities/insert.go
+++ b/storage/2026-02-06/table/entities/insert.go
@@ -1,0 +1,104 @@
+package entities
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type InsertEntityInput struct {
+	// The level of MetaData provided for this Entity
+	MetaDataLevel MetaDataLevel
+
+	// The Entity which should be inserted, by default all values are strings
+	// To explicitly type a property, specify the appropriate OData data type by setting
+	// the m:type attribute within the property definition
+	Entity map[string]interface{}
+
+	// When inserting an entity into a table, you must specify values for the PartitionKey and RowKey system properties.
+	// Together, these properties form the primary key and must be unique within the table.
+	// Both the PartitionKey and RowKey values must be string values; each key value may be up to 64 KB in size.
+	// If you are using an integer value for the key value, you should convert the integer to a fixed-width string,
+	// because they are canonically sorted. For example, you should convert the value 1 to 0000001 to ensure proper sorting.
+	RowKey       string
+	PartitionKey string
+}
+
+type InsertResponse struct {
+	HttpResponse *http.Response
+}
+
+// Insert inserts a new entity into a table.
+func (c Client) Insert(ctx context.Context, tableName string, input InsertEntityInput) (result InsertResponse, err error) {
+	if tableName == "" {
+		return result, fmt.Errorf("`tableName` cannot be an empty string")
+	}
+
+	if input.PartitionKey == "" {
+		return result, fmt.Errorf("`input.PartitionKey` cannot be an empty string")
+	}
+
+	if input.RowKey == "" {
+		return result, fmt.Errorf("`input.RowKey` cannot be an empty string")
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+		},
+		HttpMethod: http.MethodPost,
+		OptionsObject: insertOptions{
+			MetaDataLevel: input.MetaDataLevel,
+		},
+		Path: fmt.Sprintf("/%s", tableName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	input.Entity["PartitionKey"] = input.PartitionKey
+	input.Entity["RowKey"] = input.RowKey
+
+	err = req.Marshal(&input.Entity)
+	if err != nil {
+		return result, fmt.Errorf("marshalling request: %+v", err)
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type insertOptions struct {
+	MetaDataLevel MetaDataLevel
+}
+
+func (i insertOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("Accept", fmt.Sprintf("application/json;odata=%s", i.MetaDataLevel))
+	headers.Append("Prefer", "return-no-content")
+	return headers
+}
+
+func (i insertOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (i insertOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/table/entities/insert_or_merge.go
+++ b/storage/2026-02-06/table/entities/insert_or_merge.go
@@ -1,0 +1,98 @@
+package entities
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type InsertOrMergeEntityInput struct {
+	// The Entity which should be inserted, by default all values are strings
+	// To explicitly type a property, specify the appropriate OData data type by setting
+	// the m:type attribute within the property definition
+	Entity map[string]interface{}
+
+	// When inserting an entity into a table, you must specify values for the PartitionKey and RowKey system properties.
+	// Together, these properties form the primary key and must be unique within the table.
+	// Both the PartitionKey and RowKey values must be string values; each key value may be up to 64 KB in size.
+	// If you are using an integer value for the key value, you should convert the integer to a fixed-width string,
+	// because they are canonically sorted. For example, you should convert the value 1 to 0000001 to ensure proper sorting.
+	RowKey       string
+	PartitionKey string
+}
+
+type InsertOrMergeResponse struct {
+	HttpResponse *http.Response
+}
+
+// InsertOrMerge updates an existing entity or inserts a new entity if it does not exist in the table.
+// Because this operation can insert or update an entity, it is also known as an upsert operation.
+func (c Client) InsertOrMerge(ctx context.Context, tableName string, input InsertOrMergeEntityInput) (result InsertOrMergeResponse, err error) {
+	if tableName == "" {
+		return result, fmt.Errorf("`tableName` cannot be an empty string")
+	}
+
+	if input.PartitionKey == "" {
+		return result, fmt.Errorf("`input.PartitionKey` cannot be an empty string")
+	}
+
+	if input.RowKey == "" {
+		return result, fmt.Errorf("`input.RowKey` cannot be an empty string")
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+		},
+		HttpMethod:    "MERGE",
+		OptionsObject: insertOrMergeOptions{},
+		Path:          fmt.Sprintf("/%s(PartitionKey='%s', RowKey='%s')", tableName, input.PartitionKey, input.RowKey),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	input.Entity["PartitionKey"] = input.PartitionKey
+	input.Entity["RowKey"] = input.RowKey
+
+	err = req.Marshal(&input.Entity)
+	if err != nil {
+		return result, fmt.Errorf("marshalling request: %+v", err)
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type insertOrMergeOptions struct{}
+
+func (i insertOrMergeOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("Accept", "application/json")
+	headers.Append("Prefer", "return-no-content")
+	return headers
+}
+
+func (i insertOrMergeOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (i insertOrMergeOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/table/entities/insert_or_replace.go
+++ b/storage/2026-02-06/table/entities/insert_or_replace.go
@@ -1,0 +1,98 @@
+package entities
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type InsertOrReplaceEntityInput struct {
+	// The Entity which should be inserted, by default all values are strings
+	// To explicitly type a property, specify the appropriate OData data type by setting
+	// the m:type attribute within the property definition
+	Entity map[string]interface{}
+
+	// When inserting an entity into a table, you must specify values for the PartitionKey and RowKey system properties.
+	// Together, these properties form the primary key and must be unique within the table.
+	// Both the PartitionKey and RowKey values must be string values; each key value may be up to 64 KB in size.
+	// If you are using an integer value for the key value, you should convert the integer to a fixed-width string,
+	// because they are canonically sorted. For example, you should convert the value 1 to 0000001 to ensure proper sorting.
+	RowKey       string
+	PartitionKey string
+}
+
+type InsertOrReplaceResponse struct {
+	HttpResponse *http.Response
+}
+
+// InsertOrReplace replaces an existing entity or inserts a new entity if it does not exist in the table.
+// Because this operation can insert or update an entity, it is also known as an upsert operation.
+func (c Client) InsertOrReplace(ctx context.Context, tableName string, input InsertOrReplaceEntityInput) (result InsertOrReplaceResponse, err error) {
+	if tableName == "" {
+		return result, fmt.Errorf("`tableName` cannot be an empty string")
+	}
+
+	if input.PartitionKey == "" {
+		return result, fmt.Errorf("`input.PartitionKey` cannot be an empty string")
+	}
+
+	if input.RowKey == "" {
+		return result, fmt.Errorf("`input.RowKey` cannot be an empty string")
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+		},
+		HttpMethod:    "MERGE",
+		OptionsObject: insertOrReplaceOptions{},
+		Path:          fmt.Sprintf("/%s(PartitionKey='%s', RowKey='%s')", tableName, input.PartitionKey, input.RowKey),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	input.Entity["PartitionKey"] = input.PartitionKey
+	input.Entity["RowKey"] = input.RowKey
+
+	err = req.Marshal(&input.Entity)
+	if err != nil {
+		return result, fmt.Errorf("marshalling request: %+v", err)
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type insertOrReplaceOptions struct{}
+
+func (i insertOrReplaceOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("Accept", "application/json")
+	headers.Append("Prefer", "return-no-content")
+	return headers
+}
+
+func (i insertOrReplaceOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (i insertOrReplaceOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/table/entities/lifecycle_test.go
+++ b/storage/2026-02-06/table/entities/lifecycle_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
 	"github.com/hashicorp/go-azure-sdk/sdk/auth"
-	"github.com/jackofallops/giovanni/storage/2020-08-04/table/tables"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/table/tables"
 	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
 )
 

--- a/storage/2026-02-06/table/entities/lifecycle_test.go
+++ b/storage/2026-02-06/table/entities/lifecycle_test.go
@@ -1,0 +1,156 @@
+package entities
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2020-08-04/table/tables"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+var _ StorageTableEntity = Client{}
+
+func TestEntitiesLifecycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	tableName := fmt.Sprintf("table%d", testhelpers.RandomInt())
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+	tablesClient, err := tables.NewWithBaseUri(fmt.Sprintf("https://%s.%s.%s", accountName, "table", *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err := client.PrepareWithSharedKeyAuth(tablesClient.Client, testData, auth.SharedKeyTable); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	t.Logf("[DEBUG] Creating Table..")
+	if _, err := tablesClient.Create(ctx, tableName); err != nil {
+		t.Fatalf("Error creating Table %q: %s", tableName, err)
+	}
+	defer tablesClient.Delete(ctx, tableName)
+
+	entitiesClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.%s.%s", accountName, "table", *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err := client.PrepareWithSharedKeyAuth(entitiesClient.Client, testData, auth.SharedKeyTable); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	partitionKey := "hello"
+	rowKey := "there"
+
+	t.Logf("[DEBUG] Inserting..")
+	insertInput := InsertEntityInput{
+		MetaDataLevel: NoMetaData,
+		PartitionKey:  partitionKey,
+		RowKey:        rowKey,
+		Entity: map[string]interface{}{
+			"hello": "world",
+		},
+	}
+	if _, err := entitiesClient.Insert(ctx, tableName, insertInput); err != nil {
+		t.Logf("Error retrieving: %s", err)
+	}
+
+	t.Logf("[DEBUG] Insert or Merging..")
+	insertOrMergeInput := InsertOrMergeEntityInput{
+		PartitionKey: partitionKey,
+		RowKey:       rowKey,
+		Entity: map[string]interface{}{
+			"hello": "ther88e",
+		},
+	}
+	if _, err := entitiesClient.InsertOrMerge(ctx, tableName, insertOrMergeInput); err != nil {
+		t.Logf("Error insert/merging: %s", err)
+	}
+
+	t.Logf("[DEBUG] Insert or Replacing..")
+	insertOrReplaceInput := InsertOrReplaceEntityInput{
+		PartitionKey: partitionKey,
+		RowKey:       rowKey,
+		Entity: map[string]interface{}{
+			"hello": "pandas",
+		},
+	}
+	if _, err := entitiesClient.InsertOrReplace(ctx, tableName, insertOrReplaceInput); err != nil {
+		t.Logf("Error inserting/replacing: %s", err)
+	}
+
+	t.Logf("[DEBUG] Querying..")
+	queryInput := QueryEntitiesInput{
+		MetaDataLevel: NoMetaData,
+	}
+	results, err := entitiesClient.Query(ctx, tableName, queryInput)
+	if err != nil {
+		t.Logf("Error querying: %s", err)
+	}
+
+	if len(results.Entities) != 1 {
+		t.Fatalf("Expected 1 item but got %d", len(results.Entities))
+	}
+
+	for _, v := range results.Entities {
+		thisPartitionKey := v["PartitionKey"].(string)
+		thisRowKey := v["RowKey"].(string)
+		if partitionKey != thisPartitionKey {
+			t.Fatalf("Expected Partition Key to be %q but got %q", partitionKey, thisPartitionKey)
+		}
+		if rowKey != thisRowKey {
+			t.Fatalf("Expected Partition Key to be %q but got %q", rowKey, thisRowKey)
+		}
+	}
+
+	t.Logf("[DEBUG] Retrieving..")
+	getInput := GetEntityInput{
+		MetaDataLevel: MinimalMetaData,
+		PartitionKey:  partitionKey,
+		RowKey:        rowKey,
+	}
+	getResults, err := entitiesClient.Get(ctx, tableName, getInput)
+	if err != nil {
+		t.Logf("Error querying: %s", err)
+	}
+
+	partitionKey2 := getResults.Entity["PartitionKey"].(string)
+	rowKey2 := getResults.Entity["RowKey"].(string)
+	if partitionKey2 != partitionKey {
+		t.Fatalf("Expected Partition Key to be %q but got %q", partitionKey, partitionKey2)
+	}
+	if rowKey2 != rowKey {
+		t.Fatalf("Expected Row Key to be %q but got %q", rowKey, rowKey2)
+	}
+
+	t.Logf("[DEBUG] Deleting..")
+	deleteInput := DeleteEntityInput{
+		PartitionKey: partitionKey,
+		RowKey:       rowKey,
+	}
+	if _, err := entitiesClient.Delete(ctx, tableName, deleteInput); err != nil {
+		t.Logf("Error deleting: %s", err)
+	}
+}

--- a/storage/2026-02-06/table/entities/models.go
+++ b/storage/2026-02-06/table/entities/models.go
@@ -1,0 +1,9 @@
+package entities
+
+type MetaDataLevel string
+
+var (
+	NoMetaData      MetaDataLevel = "nometadata"
+	MinimalMetaData MetaDataLevel = "minimalmetadata"
+	FullMetaData    MetaDataLevel = "fullmetadata"
+)

--- a/storage/2026-02-06/table/entities/query.go
+++ b/storage/2026-02-06/table/entities/query.go
@@ -1,0 +1,145 @@
+package entities
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type QueryEntitiesInput struct {
+	// An optional OData filter
+	Filter *string
+
+	// An optional comma-separated
+	PropertyNamesToSelect *[]string
+
+	// An optional OData top
+	Top *int
+
+	PartitionKey string
+	RowKey       string
+
+	// The Level of MetaData which should be returned
+	MetaDataLevel MetaDataLevel
+
+	// The Next Partition Key used to load data from a previous point
+	NextPartitionKey *string
+
+	// The Next Row Key used to load data from a previous point
+	NextRowKey *string
+}
+
+type QueryEntitiesResponse struct {
+	HttpResponse *http.Response
+
+	NextPartitionKey string
+	NextRowKey       string
+
+	MetaData string                   `json:"odata.metadata,omitempty"`
+	Entities []map[string]interface{} `json:"value"`
+}
+
+// Query queries entities in a table and includes the $filter and $select options.
+func (c Client) Query(ctx context.Context, tableName string, input QueryEntitiesInput) (result QueryEntitiesResponse, err error) {
+	if tableName == "" {
+		return result, fmt.Errorf("`tableName` cannot be an empty string")
+	}
+
+	additionalParameters := make([]string, 0)
+	if input.PartitionKey != "" {
+		additionalParameters = append(additionalParameters, "PartitionKey='%s'", input.PartitionKey)
+	}
+
+	if input.RowKey != "" {
+		additionalParameters = append(additionalParameters, "RowKey='%s'", input.RowKey)
+	}
+
+	path := fmt.Sprintf("/%s", tableName)
+	if len(additionalParameters) > 0 {
+		path += fmt.Sprintf("(%s)", strings.Join(additionalParameters, ","))
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		OptionsObject: queryOptions{
+			input: input,
+		},
+		Path: path,
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			err = resp.Unmarshal(&result)
+			if err != nil {
+				err = fmt.Errorf("unmarshalling response: %+v", err)
+				return
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type queryOptions struct {
+	input QueryEntitiesInput
+}
+
+func (q queryOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("Accept", fmt.Sprintf("application/json;odata=%s", q.input.MetaDataLevel))
+	headers.Append("DataServiceVersion", "3.0;NetFx")
+	headers.Append("MaxDataServiceVersion", "3.0;NetFx")
+	return headers
+}
+
+func (q queryOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (q queryOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+
+	if q.input.Filter != nil {
+		out.Append("$filter", *q.input.Filter)
+	}
+
+	if q.input.PropertyNamesToSelect != nil {
+		out.Append("$select", strings.Join(*q.input.PropertyNamesToSelect, ","))
+	}
+
+	if q.input.Top != nil {
+		out.Append("$top", strconv.Itoa(*q.input.Top))
+	}
+
+	if q.input.NextPartitionKey != nil {
+		out.Append("NextPartitionKey", *q.input.NextPartitionKey)
+	}
+
+	if q.input.NextRowKey != nil {
+		out.Append("NextRowKey", *q.input.NextRowKey)
+	}
+	return out
+}

--- a/storage/2026-02-06/table/entities/resource_id.go
+++ b/storage/2026-02-06/table/entities/resource_id.go
@@ -1,0 +1,127 @@
+package entities
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+// TODO: update this to implement `resourceids.ResourceId` once
+// https://github.com/hashicorp/go-azure-helpers/issues/187 is fixed
+var _ resourceids.Id = EntityId{}
+
+type EntityId struct {
+	// AccountId specifies the ID of the Storage Account where this Entity exists.
+	AccountId accounts.AccountId
+
+	// TableName specifies the name of the Table where this Entity exists.
+	TableName string
+
+	// PartitionKey specifies the Partition Key for this Entity.
+	PartitionKey string
+
+	// RowKey specifies the Row Key for this Entity.
+	RowKey string
+}
+
+func NewEntityID(accountId accounts.AccountId, tableName, partitionKey, rowKey string) EntityId {
+	return EntityId{
+		AccountId:    accountId,
+		TableName:    tableName,
+		PartitionKey: partitionKey,
+		RowKey:       rowKey,
+	}
+}
+
+func (b EntityId) ID() string {
+	return fmt.Sprintf("%s/%s(PartitionKey='%s',RowKey='%s')", b.AccountId.ID(), b.TableName, b.PartitionKey, b.RowKey)
+}
+
+func (b EntityId) String() string {
+	components := []string{
+		fmt.Sprintf("Partition Key %q", b.PartitionKey),
+		fmt.Sprintf("Row Key %q", b.RowKey),
+		fmt.Sprintf("Table Name %q", b.TableName),
+		fmt.Sprintf("Account %q", b.AccountId.String()),
+	}
+	return fmt.Sprintf("Entity (%s)", strings.Join(components, " / "))
+}
+
+// ParseEntityID parses `input` into a Entity ID using a known `domainSuffix`
+func ParseEntityID(input, domainSuffix string) (*EntityId, error) {
+	// example: https://foo.table.core.windows.net/bar(PartitionKey='partition1',RowKey='row1')
+	if input == "" {
+		return nil, fmt.Errorf("`input` was empty")
+	}
+
+	account, err := accounts.ParseAccountID(input, domainSuffix)
+	if err != nil {
+		return nil, fmt.Errorf("parsing account %q: %+v", input, err)
+	}
+
+	if account.SubDomainType != accounts.TableSubDomainType {
+		return nil, fmt.Errorf("expected the subdomain type to be %q but got %q", string(accounts.TableSubDomainType), string(account.SubDomainType))
+	}
+
+	uri, err := url.Parse(input)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q as a uri: %+v", input, err)
+	}
+
+	path := strings.TrimPrefix(uri.Path, "/")
+	segments := strings.Split(path, "/")
+	if len(segments) != 1 {
+		return nil, fmt.Errorf("expected the path to contain 1 segment but got %d", len(segments))
+	}
+
+	// Tables and Table Entities are similar with table being `table1` and entities
+	// being `table1(PartitionKey='samplepartition',RowKey='samplerow')` so we need to validate this is a table
+	slug := strings.TrimPrefix(uri.Path, "/")
+	if strings.HasPrefix(slug, "Tables('") && strings.HasSuffix(slug, "')") {
+		// Ensure we do not parse a Table ID in the format: https://foo.table.core.windows.net/Table('foo')
+		return nil, fmt.Errorf("expected the path to be an entity name but got a table name: %q", slug)
+	} else if !strings.Contains(slug, "(") || !strings.HasSuffix(slug, ")") {
+		// Ensure we do not try to parse a bare table name
+		return nil, fmt.Errorf("expected the path to be an entity name but got an invalid format, possibly a table name: %q", slug)
+	}
+
+	indexOfFirstBracket := strings.Index(slug, "(")
+	tableName := slug[0:indexOfFirstBracket]
+	componentString := slug[indexOfFirstBracket:]
+	componentString = strings.TrimPrefix(componentString, "(")
+	componentString = strings.TrimSuffix(componentString, ")")
+	components := strings.Split(componentString, ",")
+	if len(components) != 2 {
+		return nil, fmt.Errorf("expected the path to be an entity name but got %q", slug)
+	}
+
+	partitionKey := parseValueFromKey(components[0], "PartitionKey")
+	rowKey := parseValueFromKey(components[1], "RowKey")
+
+	return &EntityId{
+		AccountId:    *account,
+		TableName:    tableName,
+		PartitionKey: *partitionKey,
+		RowKey:       *rowKey,
+	}, nil
+}
+
+func parseValueFromKey(input, expectedKey string) *string {
+	components := strings.Split(input, "=")
+	if len(components) != 2 {
+		return nil
+	}
+	key := components[0]
+	value := components[1]
+	if key != expectedKey {
+		return nil
+	}
+
+	// the value is surrounded in single quotes, remove those
+	value = strings.TrimPrefix(value, "'")
+	value = strings.TrimSuffix(value, "'")
+	return &value
+}

--- a/storage/2026-02-06/table/entities/resource_id_test.go
+++ b/storage/2026-02-06/table/entities/resource_id_test.go
@@ -1,0 +1,184 @@
+package entities
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+func TestParseEntityIDStandard(t *testing.T) {
+	input := "https://example1.table.core.windows.net/table1(PartitionKey='partition1',RowKey='row1')"
+	expected := EntityId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.TableSubDomainType,
+			DomainSuffix:  "core.windows.net",
+		},
+		TableName:    "table1",
+		PartitionKey: "partition1",
+		RowKey:       "row1",
+	}
+	actual, err := ParseEntityID(input, "core.windows.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if actual.TableName != expected.TableName {
+		t.Fatalf("expected TableName to be %q but got %q", expected.TableName, actual.TableName)
+	}
+	if actual.PartitionKey != expected.PartitionKey {
+		t.Fatalf("expected PartitionKey to be %q but got %q", expected.PartitionKey, actual.PartitionKey)
+	}
+	if actual.RowKey != expected.RowKey {
+		t.Fatalf("expected RowKey to be %q but got %q", expected.RowKey, actual.RowKey)
+	}
+}
+
+func TestParseEntityIDInADNSZone(t *testing.T) {
+	input := "https://example1.zone1.table.storage.azure.net/table1(PartitionKey='partition1',RowKey='row1')"
+	expected := EntityId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.TableSubDomainType,
+			DomainSuffix:  "storage.azure.net",
+			ZoneName:      pointer.To("zone1"),
+		},
+		TableName:    "table1",
+		PartitionKey: "partition1",
+		RowKey:       "row1",
+	}
+	actual, err := ParseEntityID(input, "storage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if pointer.From(actual.AccountId.ZoneName) != pointer.From(expected.AccountId.ZoneName) {
+		t.Fatalf("expected ZoneName to be %q but got %q", pointer.From(expected.AccountId.ZoneName), pointer.From(actual.AccountId.ZoneName))
+	}
+	if actual.TableName != expected.TableName {
+		t.Fatalf("expected TableName to be %q but got %q", expected.TableName, actual.TableName)
+	}
+	if actual.PartitionKey != expected.PartitionKey {
+		t.Fatalf("expected PartitionKey to be %q but got %q", expected.PartitionKey, actual.PartitionKey)
+	}
+	if actual.RowKey != expected.RowKey {
+		t.Fatalf("expected RowKey to be %q but got %q", expected.RowKey, actual.RowKey)
+	}
+}
+
+func TestParseEntityIDInAnEdgeZone(t *testing.T) {
+	input := "https://example1.table.zone1.edgestorage.azure.net/table1(PartitionKey='partition1',RowKey='row1')"
+	expected := EntityId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.TableSubDomainType,
+			DomainSuffix:  "edgestorage.azure.net",
+			ZoneName:      pointer.To("zone1"),
+			IsEdgeZone:    true,
+		},
+		TableName:    "table1",
+		PartitionKey: "partition1",
+		RowKey:       "row1",
+	}
+	actual, err := ParseEntityID(input, "edgestorage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if pointer.From(actual.AccountId.ZoneName) != pointer.From(expected.AccountId.ZoneName) {
+		t.Fatalf("expected ZoneName to be %q but got %q", pointer.From(expected.AccountId.ZoneName), pointer.From(actual.AccountId.ZoneName))
+	}
+	if !actual.AccountId.IsEdgeZone {
+		t.Fatalf("expected the Account to be in an Edge Zone but it wasn't")
+	}
+	if actual.TableName != expected.TableName {
+		t.Fatalf("expected TableName to be %q but got %q", expected.TableName, actual.TableName)
+	}
+	if actual.PartitionKey != expected.PartitionKey {
+		t.Fatalf("expected PartitionKey to be %q but got %q", expected.PartitionKey, actual.PartitionKey)
+	}
+	if actual.RowKey != expected.RowKey {
+		t.Fatalf("expected RowKey to be %q but got %q", expected.RowKey, actual.RowKey)
+	}
+}
+
+func TestFormatEntityIDStandard(t *testing.T) {
+	actual := EntityId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.TableSubDomainType,
+			DomainSuffix:  "core.windows.net",
+			IsEdgeZone:    false,
+		},
+		TableName:    "table1",
+		PartitionKey: "partition1",
+		RowKey:       "row1",
+	}.ID()
+	expected := "https://example1.table.core.windows.net/table1(PartitionKey='partition1',RowKey='row1')"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatEntityIDInDNSZone(t *testing.T) {
+	actual := EntityId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			ZoneName:      pointer.To("zone2"),
+			SubDomainType: accounts.TableSubDomainType,
+			DomainSuffix:  "storage.azure.net",
+			IsEdgeZone:    false,
+		},
+		TableName:    "table1",
+		PartitionKey: "partition1",
+		RowKey:       "row1",
+	}.ID()
+	expected := "https://example1.zone2.table.storage.azure.net/table1(PartitionKey='partition1',RowKey='row1')"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatEntityIDInEdgeZone(t *testing.T) {
+	actual := EntityId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			ZoneName:      pointer.To("zone2"),
+			SubDomainType: accounts.TableSubDomainType,
+			DomainSuffix:  "edgestorage.azure.net",
+			IsEdgeZone:    true,
+		},
+		TableName:    "table1",
+		PartitionKey: "partition1",
+		RowKey:       "row1",
+	}.ID()
+	expected := "https://example1.table.zone2.edgestorage.azure.net/table1(PartitionKey='partition1',RowKey='row1')"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}

--- a/storage/2026-02-06/table/entities/version.go
+++ b/storage/2026-02-06/table/entities/version.go
@@ -1,0 +1,4 @@
+package entities
+
+const apiVersion = "2026-02-06"
+const componentName = "table/entities"

--- a/storage/2026-02-06/table/tables/README.md
+++ b/storage/2026-02-06/table/tables/README.md
@@ -1,0 +1,45 @@
+## Table Storage Tables SDK for API version 2026-02-06
+
+This package allows you to interact with the Tables Table Storage API
+
+### Supported Authorizers
+
+* SharedKeyLite (Table)
+
+### Example Usage
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/table/tables"
+)
+
+func Example() error {
+	accountName := "storageaccount1"
+    storageAccountKey := "ABC123...."
+    tableName := "mytable"
+	domainSuffix := "core.windows.net"
+
+	auth, err := auth.NewSharedKeyAuthorizer(accountName, storageAccountKey, auth.SharedKeyTable)
+	if err != nil {
+		return fmt.Errorf("building SharedKey authorizer: %+v", err)
+	}
+    tablesClient, err := tables.NewWithBaseUri(fmt.Sprintf("https://%s.table.%s", accountName, domainSuffix))
+	if err != nil {
+		return fmt.Errorf("building client for environment: %+v", err)
+	}
+	tablesClient.Client.SetAuthorizer(auth)
+    
+    ctx := context.TODO()
+    if _, err := tablesClient.Create(ctx, tableName); err != nil {
+        return fmt.Errorf("Error creating Table: %s", err)
+    }
+    
+    return nil 
+}
+```

--- a/storage/2026-02-06/table/tables/acl_get.go
+++ b/storage/2026-02-06/table/tables/acl_get.go
@@ -1,0 +1,77 @@
+package tables
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type GetACLResponse struct {
+	HttpResponse *http.Response
+
+	SignedIdentifiers []SignedIdentifier `xml:"SignedIdentifier"`
+}
+
+// GetACL returns the Access Control List for the specified Table
+func (c Client) GetACL(ctx context.Context, tableName string) (result GetACLResponse, err error) {
+
+	if tableName == "" {
+		err = fmt.Errorf("`tableName` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: getAclTableOptions{},
+		Path:          fmt.Sprintf("/%s", tableName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			err = resp.Unmarshal(&result)
+			if err != nil {
+				err = fmt.Errorf("unmarshalling response: %+v", err)
+				return
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type getAclTableOptions struct{}
+
+func (g getAclTableOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (g getAclTableOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (g getAclTableOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "acl")
+	return out
+}

--- a/storage/2026-02-06/table/tables/acl_set.go
+++ b/storage/2026-02-06/table/tables/acl_set.go
@@ -1,0 +1,79 @@
+package tables
+
+import (
+	"context"
+	"encoding/xml"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type setAcl struct {
+	SignedIdentifiers []SignedIdentifier `xml:"SignedIdentifier"`
+
+	XMLName xml.Name `xml:"SignedIdentifiers"`
+}
+
+type SetACLResponse struct {
+	HttpResponse *http.Response
+}
+
+// SetACL sets the specified Access Control List for the specified Table
+func (c Client) SetACL(ctx context.Context, tableName string, acls []SignedIdentifier) (result SetACLResponse, err error) {
+	if tableName == "" {
+		err = fmt.Errorf("`tableName` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/xml; charset=utf-8",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+		},
+		HttpMethod:    http.MethodPut,
+		OptionsObject: setAclTableOptions{},
+		Path:          fmt.Sprintf("/%s", tableName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	err = req.Marshal(setAcl{SignedIdentifiers: acls})
+	if err != nil {
+		err = fmt.Errorf("marshalling request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type setAclTableOptions struct{}
+
+func (s setAclTableOptions) ToHeaders() *client.Headers {
+	return nil
+}
+
+func (s setAclTableOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (s setAclTableOptions) ToQuery() *client.QueryParams {
+	out := &client.QueryParams{}
+	out.Append("comp", "acl")
+	return out
+}

--- a/storage/2026-02-06/table/tables/api.go
+++ b/storage/2026-02-06/table/tables/api.go
@@ -1,0 +1,15 @@
+package tables
+
+import (
+	"context"
+)
+
+type StorageTable interface {
+	Delete(ctx context.Context, tableName string) (resp DeleteTableResponse, err error)
+	Exists(ctx context.Context, tableName string) (resp TableExistsResponse, err error)
+	GetACL(ctx context.Context, tableName string) (resp GetACLResponse, err error)
+	Create(ctx context.Context, tableName string) (resp CreateTableResponse, err error)
+	GetResourceManagerResourceID(subscriptionID, resourceGroup, accountName, tableName string) string
+	Query(ctx context.Context, input QueryInput) (resp GetResponse, err error)
+	SetACL(ctx context.Context, tableName string, acls []SignedIdentifier) (resp SetACLResponse, err error)
+}

--- a/storage/2026-02-06/table/tables/client.go
+++ b/storage/2026-02-06/table/tables/client.go
@@ -1,0 +1,23 @@
+package tables
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client/dataplane/storage"
+)
+
+// Client is the base client for Table Storage Shares.
+type Client struct {
+	Client *storage.Client
+}
+
+func NewWithBaseUri(baseUri string) (*Client, error) {
+	baseClient, err := storage.NewStorageClient(baseUri, componentName, apiVersion)
+	if err != nil {
+		return nil, fmt.Errorf("building base client: %+v", err)
+	}
+
+	return &Client{
+		Client: baseClient,
+	}, nil
+}

--- a/storage/2026-02-06/table/tables/create.go
+++ b/storage/2026-02-06/table/tables/create.go
@@ -1,0 +1,76 @@
+package tables
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type createTableRequest struct {
+	TableName string `json:"TableName"`
+}
+
+type CreateTableResponse struct {
+	HttpResponse *http.Response
+}
+
+// Create creates a new table in the storage account.
+func (c Client) Create(ctx context.Context, tableName string) (result CreateTableResponse, err error) {
+	if tableName == "" {
+		err = fmt.Errorf("`tableName` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+		},
+		HttpMethod:    http.MethodPost,
+		OptionsObject: createTableOptions{},
+		Path:          "/Tables",
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	err = req.Marshal(&createTableRequest{TableName: tableName})
+	if err != nil {
+		return result, fmt.Errorf("marshalling request")
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type createTableOptions struct{}
+
+func (c createTableOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("Accept", "application/json;odata=nometadata")
+	headers.Append("Prefer", "return-no-content")
+	return headers
+}
+
+func (c createTableOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (c createTableOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/table/tables/delete.go
+++ b/storage/2026-02-06/table/tables/delete.go
@@ -1,0 +1,67 @@
+package tables
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type DeleteTableResponse struct {
+	HttpResponse *http.Response
+}
+
+// Delete deletes the specified table and any data it contains.
+func (c Client) Delete(ctx context.Context, tableName string) (result DeleteTableResponse, err error) {
+	if tableName == "" {
+		err = fmt.Errorf("`tableName` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusNoContent,
+		},
+		HttpMethod:    http.MethodDelete,
+		OptionsObject: deleteOptions{},
+		Path:          fmt.Sprintf("/Tables('%s')", tableName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type deleteOptions struct {
+}
+
+func (d deleteOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("Accept", "application/json")
+	return headers
+}
+
+func (d deleteOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (d deleteOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/table/tables/exists.go
+++ b/storage/2026-02-06/table/tables/exists.go
@@ -1,0 +1,66 @@
+package tables
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type TableExistsResponse struct {
+	HttpResponse *http.Response
+}
+
+// Exists checks that the specified table exists
+func (c Client) Exists(ctx context.Context, tableName string) (result TableExistsResponse, err error) {
+	if tableName == "" {
+		err = fmt.Errorf("`tableName` cannot be an empty string")
+		return
+	}
+
+	opts := client.RequestOptions{
+		ContentType: "application/json",
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod:    http.MethodGet,
+		OptionsObject: tableExistsOptions{},
+		Path:          fmt.Sprintf("/Tables('%s')", tableName),
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type tableExistsOptions struct{}
+
+func (t tableExistsOptions) ToHeaders() *client.Headers {
+	headers := &client.Headers{}
+	headers.Append("Accept", "application/json;odata=nometadata")
+	return headers
+}
+
+func (t tableExistsOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (t tableExistsOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/table/tables/lifecycle_test.go
+++ b/storage/2026-02-06/table/tables/lifecycle_test.go
@@ -1,0 +1,127 @@
+package tables
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/go-azure-sdk/resource-manager/storage/2023-01-01/storageaccounts"
+	"github.com/hashicorp/go-azure-sdk/sdk/auth"
+	"github.com/jackofallops/giovanni/storage/internal/testhelpers"
+)
+
+var _ StorageTable = Client{}
+
+func TestTablesLifecycle(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+	defer cancel()
+
+	client, err := testhelpers.Build(ctx, t)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resourceGroup := fmt.Sprintf("acctestrg-%d", testhelpers.RandomInt())
+	accountName := fmt.Sprintf("acctestsa%s", testhelpers.RandomString())
+	tableName := fmt.Sprintf("table%d", testhelpers.RandomInt())
+
+	testData, err := client.BuildTestResources(ctx, resourceGroup, accountName, storageaccounts.KindStorage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer client.DestroyTestResources(ctx, resourceGroup, accountName)
+
+	domainSuffix, ok := client.Environment.Storage.DomainSuffix()
+	if !ok {
+		t.Fatalf("storage didn't return a domain suffix for this environment")
+	}
+	tablesClient, err := NewWithBaseUri(fmt.Sprintf("https://%s.%s.%s", accountName, "table", *domainSuffix))
+	if err != nil {
+		t.Fatalf("building client for environment: %+v", err)
+	}
+
+	if err := client.PrepareWithSharedKeyAuth(tablesClient.Client, testData, auth.SharedKeyTable); err != nil {
+		t.Fatalf("adding authorizer to client: %+v", err)
+	}
+
+	t.Logf("[DEBUG] Creating Table..")
+	if _, err := tablesClient.Create(ctx, tableName); err != nil {
+		t.Fatalf("Error creating Table %q: %s", tableName, err)
+	}
+
+	// first look it up directly and confirm it's there
+	t.Logf("[DEBUG] Checking if Table exists..")
+	if _, err := tablesClient.Exists(ctx, tableName); err != nil {
+		t.Fatalf("Error checking if Table %q exists: %s", tableName, err)
+	}
+
+	// then confirm it exists in the Query too
+	t.Logf("[DEBUG] Querying for Tables..")
+	result, err := tablesClient.Query(ctx, QueryInput{MetaDataLevel: NoMetaData})
+	if err != nil {
+		t.Fatalf("Error retrieving Tables: %s", err)
+	}
+	found := false
+	for _, v := range result.Tables {
+		log.Printf("[DEBUG] Table: %q", v.TableName)
+
+		if v.TableName == tableName {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("%q was not found in the Query response!", tableName)
+	}
+
+	t.Logf("[DEBUG] Setting ACL's for Table %q..", tableName)
+	acls := []SignedIdentifier{
+		{
+			Id: "MTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwMTI=",
+			AccessPolicy: AccessPolicy{
+				Permission: "raud",
+				Start:      "2020-11-26T08:49:37.0000000Z",
+				Expiry:     "2020-11-27T08:49:37.0000000Z",
+			},
+		},
+	}
+	if _, err := tablesClient.SetACL(ctx, tableName, acls); err != nil {
+		t.Fatalf("Error setting ACLs: %s", err)
+	}
+
+	t.Logf("[DEBUG] Retrieving ACL's for Table %q..", tableName)
+	retrievedACLs, err := tablesClient.GetACL(ctx, tableName)
+	if err != nil {
+		t.Fatalf("Error retrieving ACLs: %s", err)
+	}
+
+	if len(retrievedACLs.SignedIdentifiers) != len(acls) {
+		t.Fatalf("Expected %d but got %q ACLs", len(acls), len(retrievedACLs.SignedIdentifiers))
+	}
+
+	for i, retrievedAcl := range retrievedACLs.SignedIdentifiers {
+		expectedAcl := acls[i]
+
+		if retrievedAcl.Id != expectedAcl.Id {
+			t.Fatalf("Expected ID to be %q but got %q", expectedAcl.Id, retrievedAcl.Id)
+		}
+
+		if retrievedAcl.AccessPolicy.Start != expectedAcl.AccessPolicy.Start {
+			t.Fatalf("Expected Start to be %q but got %q", expectedAcl.AccessPolicy.Start, retrievedAcl.AccessPolicy.Start)
+		}
+
+		if retrievedAcl.AccessPolicy.Expiry != expectedAcl.AccessPolicy.Expiry {
+			t.Fatalf("Expected Expiry to be %q but got %q", expectedAcl.AccessPolicy.Expiry, retrievedAcl.AccessPolicy.Expiry)
+		}
+
+		if retrievedAcl.AccessPolicy.Permission != expectedAcl.AccessPolicy.Permission {
+			t.Fatalf("Expected Permission to be %q but got %q", expectedAcl.AccessPolicy.Permission, retrievedAcl.AccessPolicy.Permission)
+		}
+	}
+
+	t.Logf("[DEBUG] Deleting Table %q..", tableName)
+	if _, err := tablesClient.Delete(ctx, tableName); err != nil {
+		t.Fatalf("Error deleting %q: %s", tableName, err)
+	}
+}

--- a/storage/2026-02-06/table/tables/models.go
+++ b/storage/2026-02-06/table/tables/models.go
@@ -1,0 +1,29 @@
+package tables
+
+type MetaDataLevel string
+
+var (
+	NoMetaData      MetaDataLevel = "nometadata"
+	MinimalMetaData MetaDataLevel = "minimalmetadata"
+	FullMetaData    MetaDataLevel = "fullmetadata"
+)
+
+type GetResultItem struct {
+	TableName string `json:"TableName"`
+
+	// Optional, depending on the MetaData Level
+	ODataType     string `json:"odata.type,omitempty"`
+	ODataID       string `json:"odata.id,omitEmpty"`
+	ODataEditLink string `json:"odata.editLink,omitEmpty"`
+}
+
+type SignedIdentifier struct {
+	Id           string       `xml:"Id"`
+	AccessPolicy AccessPolicy `xml:"AccessPolicy"`
+}
+
+type AccessPolicy struct {
+	Start      string `xml:"Start"`
+	Expiry     string `xml:"Expiry"`
+	Permission string `xml:"Permission"`
+}

--- a/storage/2026-02-06/table/tables/query.go
+++ b/storage/2026-02-06/table/tables/query.go
@@ -1,0 +1,83 @@
+package tables
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/hashicorp/go-azure-sdk/sdk/client"
+	"github.com/hashicorp/go-azure-sdk/sdk/odata"
+)
+
+type GetResponse struct {
+	HttpResponse *http.Response
+
+	MetaData string          `json:"odata.metadata,omitempty"`
+	Tables   []GetResultItem `json:"value"`
+}
+
+type QueryInput struct {
+	MetaDataLevel MetaDataLevel
+}
+
+// Query returns a list of tables under the specified account.
+func (c Client) Query(ctx context.Context, input QueryInput) (result GetResponse, err error) {
+
+	opts := client.RequestOptions{
+		ExpectedStatusCodes: []int{
+			http.StatusOK,
+		},
+		HttpMethod: http.MethodGet,
+		OptionsObject: queryOptions{
+			metaDataLevel: input.MetaDataLevel,
+		},
+		Path: "/Tables",
+	}
+
+	req, err := c.Client.NewRequest(ctx, opts)
+	if err != nil {
+		err = fmt.Errorf("building request: %+v", err)
+		return
+	}
+
+	var resp *client.Response
+	resp, err = req.Execute(ctx)
+	if resp != nil && resp.Response != nil {
+		result.HttpResponse = resp.Response
+
+		if err == nil {
+			err = resp.Unmarshal(&result)
+			if err != nil {
+				err = fmt.Errorf("unmarshalling response: %+v", err)
+				return
+			}
+		}
+	}
+	if err != nil {
+		err = fmt.Errorf("executing request: %+v", err)
+		return
+	}
+
+	return
+}
+
+type queryOptions struct {
+	metaDataLevel MetaDataLevel
+}
+
+func (q queryOptions) ToHeaders() *client.Headers {
+	// NOTE: whilst this supports ContinuationTokens and 'Top'
+	// it appears that 'Skip' returns a '501 Not Implemented'
+	// as such, we intentionally don't support those right now
+	headers := &client.Headers{}
+	headers.Append("Accept", fmt.Sprintf("application/json;odata=%s", q.metaDataLevel))
+	return headers
+}
+
+func (q queryOptions) ToOData() *odata.Query {
+	return nil
+}
+
+func (q queryOptions) ToQuery() *client.QueryParams {
+	return nil
+}

--- a/storage/2026-02-06/table/tables/resource_id.go
+++ b/storage/2026-02-06/table/tables/resource_id.go
@@ -1,0 +1,101 @@
+package tables
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/hashicorp/go-azure-helpers/resourcemanager/resourceids"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+// GetResourceManagerResourceID returns the Resource ID for the given Table
+// This can be useful when, for example, you're using this as a unique identifier
+func (c Client) GetResourceManagerResourceID(subscriptionID, resourceGroup, accountName, tableName string) string {
+	fmtStr := "/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Storage/storageAccounts/%s/tableServices/default/tables/%s"
+	return fmt.Sprintf(fmtStr, subscriptionID, resourceGroup, accountName, tableName)
+}
+
+// TODO: update this to implement `resourceids.ResourceId` once
+// https://github.com/hashicorp/go-azure-helpers/issues/187 is fixed
+var _ resourceids.Id = TableId{}
+
+type TableId struct {
+	// AccountId specifies the ID of the Storage Account where this Table exists.
+	AccountId accounts.AccountId
+
+	// TableName specifies the name of this Table.
+	TableName string
+}
+
+func NewTableID(accountId accounts.AccountId, tableName string) TableId {
+	return TableId{
+		AccountId: accountId,
+		TableName: tableName,
+	}
+}
+
+func (b TableId) ID() string {
+	return fmt.Sprintf("%s/Tables('%s')", b.AccountId.ID(), b.TableName)
+}
+
+func (b TableId) String() string {
+	components := []string{
+		fmt.Sprintf("Account %q", b.AccountId.String()),
+	}
+	return fmt.Sprintf("Table %q (%s)", b.TableName, strings.Join(components, " / "))
+}
+
+// ParseTableID parses `input` into a Table ID using a known `domainSuffix`
+func ParseTableID(input, domainSuffix string) (*TableId, error) {
+	// example: https://foo.table.core.windows.net/Table('bar')
+	if input == "" {
+		return nil, fmt.Errorf("`input` was empty")
+	}
+
+	account, err := accounts.ParseAccountID(input, domainSuffix)
+	if err != nil {
+		return nil, fmt.Errorf("parsing account %q: %+v", input, err)
+	}
+
+	if account.SubDomainType != accounts.TableSubDomainType {
+		return nil, fmt.Errorf("expected the subdomain type to be %q but got %q", string(accounts.TableSubDomainType), string(account.SubDomainType))
+	}
+
+	uri, err := url.Parse(input)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %q as a uri: %+v", input, err)
+	}
+
+	path := strings.TrimPrefix(uri.Path, "/")
+	segments := strings.Split(path, "/")
+	if len(segments) != 1 {
+		return nil, fmt.Errorf("expected the path to contain 1 segment but got %d", len(segments))
+	}
+
+	// Tables and Table Entities are similar however Tables use a reserved namespace, for example:
+	//   Table('tableName')
+	// whereas Entities begin with the actual table name, for example:
+	//   tableName(PartitionKey='samplepartition',RowKey='samplerow')
+	// However, there was a period of time when Table IDs did not use the reserved namespace, so we attempt to parse
+	// both forms for maximum compatibility.
+	var tableName string
+	slug := strings.TrimPrefix(uri.Path, "/")
+	if strings.HasPrefix(slug, "Tables('") && strings.HasSuffix(slug, "')") {
+		// Ensure both prefix and suffix are present before trimming them out
+		tableName = strings.TrimSuffix(strings.TrimPrefix(slug, "Tables('"), "')")
+	} else if !strings.Contains(slug, "(") && !strings.HasSuffix(slug, ")") {
+		// Also accept a bare table name
+		tableName = slug
+	} else {
+		return nil, fmt.Errorf("expected the path to a table name and not an entity name but got %q", tableName)
+	}
+	if tableName == "" {
+		return nil, fmt.Errorf("expected the path to a table name but the path was empty")
+	}
+
+	return &TableId{
+		AccountId: *account,
+		TableName: tableName,
+	}, nil
+}

--- a/storage/2026-02-06/table/tables/resource_id_test.go
+++ b/storage/2026-02-06/table/tables/resource_id_test.go
@@ -1,0 +1,190 @@
+package tables
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-azure-helpers/lang/pointer"
+	"github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts"
+)
+
+func TestGetResourceManagerResourceID(t *testing.T) {
+	actual := Client{}.GetResourceManagerResourceID("11112222-3333-4444-5555-666677778888", "group1", "account1", "table1")
+	expected := "/subscriptions/11112222-3333-4444-5555-666677778888/resourceGroups/group1/providers/Microsoft.Storage/storageAccounts/account1/tableServices/default/tables/table1"
+	if actual != expected {
+		t.Fatalf("Expected the Resource Manager Resource ID to be %q but got %q", expected, actual)
+	}
+}
+
+func TestParseTableIDStandard(t *testing.T) {
+	input := "https://example1.table.core.windows.net/Tables('table1')"
+	expected := TableId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.TableSubDomainType,
+			DomainSuffix:  "core.windows.net",
+		},
+		TableName: "table1",
+	}
+	actual, err := ParseTableID(input, "core.windows.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if actual.TableName != expected.TableName {
+		t.Fatalf("expected TableName to be %q but got %q", expected.TableName, actual.TableName)
+	}
+}
+
+func TestParseTableIDLegacy(t *testing.T) {
+	input := "https://example1.table.core.windows.net/table1"
+	expected := TableId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.TableSubDomainType,
+			DomainSuffix:  "core.windows.net",
+		},
+		TableName: "table1",
+	}
+	actual, err := ParseTableID(input, "core.windows.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if actual.TableName != expected.TableName {
+		t.Fatalf("expected TableName to be %q but got %q", expected.TableName, actual.TableName)
+	}
+}
+
+func TestParseTableIDInADNSZone(t *testing.T) {
+	input := "https://example1.zone1.table.storage.azure.net/Tables('table1')"
+	expected := TableId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.TableSubDomainType,
+			DomainSuffix:  "storage.azure.net",
+			ZoneName:      pointer.To("zone1"),
+		},
+		TableName: "table1",
+	}
+	actual, err := ParseTableID(input, "storage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if pointer.From(actual.AccountId.ZoneName) != pointer.From(expected.AccountId.ZoneName) {
+		t.Fatalf("expected ZoneName to be %q but got %q", pointer.From(expected.AccountId.ZoneName), pointer.From(actual.AccountId.ZoneName))
+	}
+	if actual.TableName != expected.TableName {
+		t.Fatalf("expected TableName to be %q but got %q", expected.TableName, actual.TableName)
+	}
+}
+
+func TestParseTableIDInAnEdgeZone(t *testing.T) {
+	input := "https://example1.table.zone1.edgestorage.azure.net/Tables('table1')"
+	expected := TableId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.TableSubDomainType,
+			DomainSuffix:  "edgestorage.azure.net",
+			ZoneName:      pointer.To("zone1"),
+			IsEdgeZone:    true,
+		},
+		TableName: "table1",
+	}
+	actual, err := ParseTableID(input, "edgestorage.azure.net")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if actual.AccountId.AccountName != expected.AccountId.AccountName {
+		t.Fatalf("expected AccountName to be %q but got %q", expected.AccountId.AccountName, actual.AccountId.AccountName)
+	}
+	if actual.AccountId.SubDomainType != expected.AccountId.SubDomainType {
+		t.Fatalf("expected SubDomainType to be %q but got %q", expected.AccountId.SubDomainType, actual.AccountId.SubDomainType)
+	}
+	if actual.AccountId.DomainSuffix != expected.AccountId.DomainSuffix {
+		t.Fatalf("expected DomainSuffix to be %q but got %q", expected.AccountId.DomainSuffix, actual.AccountId.DomainSuffix)
+	}
+	if pointer.From(actual.AccountId.ZoneName) != pointer.From(expected.AccountId.ZoneName) {
+		t.Fatalf("expected ZoneName to be %q but got %q", pointer.From(expected.AccountId.ZoneName), pointer.From(actual.AccountId.ZoneName))
+	}
+	if !actual.AccountId.IsEdgeZone {
+		t.Fatalf("expected the Account to be in an Edge Zone but it wasn't")
+	}
+	if actual.TableName != expected.TableName {
+		t.Fatalf("expected TableName to be %q but got %q", expected.TableName, actual.TableName)
+	}
+}
+
+func TestFormatTableIDStandard(t *testing.T) {
+	actual := TableId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			SubDomainType: accounts.TableSubDomainType,
+			DomainSuffix:  "core.windows.net",
+			IsEdgeZone:    false,
+		},
+		TableName: "table1",
+	}.ID()
+	expected := "https://example1.table.core.windows.net/Tables('table1')"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatTableIDInDNSZone(t *testing.T) {
+	actual := TableId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			ZoneName:      pointer.To("zone2"),
+			SubDomainType: accounts.TableSubDomainType,
+			DomainSuffix:  "storage.azure.net",
+			IsEdgeZone:    false,
+		},
+		TableName: "table1",
+	}.ID()
+	expected := "https://example1.zone2.table.storage.azure.net/Tables('table1')"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}
+
+func TestFormatTableIDInEdgeZone(t *testing.T) {
+	actual := TableId{
+		AccountId: accounts.AccountId{
+			AccountName:   "example1",
+			ZoneName:      pointer.To("zone2"),
+			SubDomainType: accounts.TableSubDomainType,
+			DomainSuffix:  "edgestorage.azure.net",
+			IsEdgeZone:    true,
+		},
+		TableName: "table1",
+	}.ID()
+	expected := "https://example1.table.zone2.edgestorage.azure.net/Tables('table1')"
+	if actual != expected {
+		t.Fatalf("expected %q but got %q", expected, actual)
+	}
+}

--- a/storage/2026-02-06/table/tables/version.go
+++ b/storage/2026-02-06/table/tables/version.go
@@ -1,0 +1,4 @@
+package tables
+
+const apiVersion = "2026-02-06"
+const componentName = "table/tables"


### PR DESCRIPTION
This PR adds support for storage data plane API version `2026-02-06`.

Note: `2026-02-06` seems to be a future version, but is defined in the swagger as the latest stable version, which really works.

What I've been doing is simply copying the `2023-11-03` folder to this new one, and do a global text based replacement from `2023-11-03` to `2026-02-06`.

## Test

```shell
storage/2026-02-06/table on  new_api_version_20260206 [?]
❯ ACCTEST=1 go test ./...
ok      github.com/jackofallops/giovanni/storage/2026-02-06/table/entities      57.499s
ok      github.com/jackofallops/giovanni/storage/2026-02-06/table/tables        54.414s

storage/2026-02-06/queue on  new_api_version_20260206 [?]
❯ ACCTEST=1 go test ./...
ok      github.com/jackofallops/giovanni/storage/2026-02-06/queue/messages      (cached)
ok      github.com/jackofallops/giovanni/storage/2026-02-06/queue/queues        57.438s

storage/2026-02-06/datalakestore on  new_api_version_20260206 [?]
❯ ACCTEST=1 go test ./...
ok      github.com/jackofallops/giovanni/storage/2026-02-06/datalakestore/filesystems   105.936s
ok      github.com/jackofallops/giovanni/storage/2026-02-06/datalakestore/paths 101.506s

storage/2026-02-06/file on  new_api_version_20260206 [?]
❯ ACCTEST=1 go test -timeout 30m ./...
ok      github.com/jackofallops/giovanni/storage/2026-02-06/file/directories    58.458s
ok      github.com/jackofallops/giovanni/storage/2026-02-06/file/files  797.965s
ok      github.com/jackofallops/giovanni/storage/2026-02-06/file/shares 160.770s

storage/2026-02-06/blob on  new_api_version_20260206 [?]
❯ ACCTEST=1 go test -timeout 30m ./...
ok      github.com/jackofallops/giovanni/storage/2026-02-06/blob/accounts       56.877s
ok      github.com/jackofallops/giovanni/storage/2026-02-06/blob/blobs  1129.265s
ok      github.com/jackofallops/giovanni/storage/2026-02-06/blob/containers     70.218s
```