### PR TITLE
Change semantic of `accounts.ParseAccountID()` to accept the cloud dependent regular domain suffix

### DIFF
--- a/storage/2023-11-03/blob/accounts/resource_id.go
+++ b/storage/2023-11-03/blob/accounts/resource_id.go
@@ -2,6 +2,7 @@ package accounts
 
 import (
 	"fmt"
+	"log"
 	"net/url"
 	"strings"
 
@@ -76,14 +77,10 @@ func (a AccountId) String() string {
 	return fmt.Sprintf("Account %q (%s)", a.AccountName, strings.Join(components, " / "))
 }
 
-func ParseAccountID(input, domainSuffix string) (*AccountId, error) {
+func ParseAccountID(input, regularDomainSuffix string) (*AccountId, error) {
 	uri, err := url.Parse(input)
 	if err != nil {
 		return nil, fmt.Errorf("parsing %q as a URL: %s", input, err)
-	}
-
-	if !strings.HasSuffix(uri.Host, domainSuffix) {
-		return nil, fmt.Errorf("expected the account %q to use a domain suffix of %q", uri.Host, domainSuffix)
 	}
 
 	// There's 3 different types of Storage Account ID:
@@ -95,16 +92,45 @@ func ParseAccountID(input, domainSuffix string) (*AccountId, error) {
 	//   `{accountname}.{component}.{edgezone}.edgestorage.azure.net`
 	// since both `dnszone` and `edgezone` are the only two identifiers, we need to check if `domainSuffix` includes `edge`
 	// to know how to treat these
+	type domainType int
+	const (
+		unknownDomain domainType = iota
+		regularDomain
+		dnsZoneDomain
+		edgeZoneDomain
+	)
 
+	validDomainSuffixes := map[domainType]string{
+		regularDomain:  regularDomainSuffix,
+		dnsZoneDomain:  "storage.azure.net",
+		edgeZoneDomain: "edgestorage.azure.net",
+	}
+
+	dt := unknownDomain
+	for k, suffix := range validDomainSuffixes {
+		if strings.HasSuffix(uri.Host, "."+suffix) {
+			dt = k
+			break
+		}
+	}
+	if dt == unknownDomain {
+		return nil, fmt.Errorf("invalid domain suffix of account %q", uri.Host)
+	}
+	log.Println(dt)
+
+	domainSuffix := validDomainSuffixes[dt]
 	hostName := strings.TrimSuffix(uri.Host, fmt.Sprintf(".%s", domainSuffix))
 	components := strings.Split(hostName, ".")
 	accountId := AccountId{
 		DomainSuffix: domainSuffix,
-		IsEdgeZone:   strings.Contains(strings.ToLower(domainSuffix), "edge"),
+		IsEdgeZone:   dt == edgeZoneDomain,
 	}
 
-	if len(components) == 2 {
-		// this will be a regular Storage Account (e.g. `example1.blob.core.windows.net`)
+	switch dt {
+	case regularDomain:
+		if l := len(components); l != 2 {
+			return nil, fmt.Errorf("expect 2 uri components before the domain suffix %q, got=%d", domainSuffix, l)
+		}
 		accountId.AccountName = components[0]
 		subDomainType, err := parseSubDomainType(components[1])
 		if err != nil {
@@ -112,32 +138,29 @@ func ParseAccountID(input, domainSuffix string) (*AccountId, error) {
 		}
 		accountId.SubDomainType = *subDomainType
 		return &accountId, nil
-	}
-
-	if len(components) == 3 {
-		// This can either be a Zone'd Storage Account or a Storage Account within an Edge Zone
-		accountName := ""
-		subDomainTypeRaw := ""
-		zone := ""
-		if accountId.IsEdgeZone {
-			// `{accountname}.{component}.{edgezone}.edgestorage.azure.net`
-			accountName = components[0]
-			subDomainTypeRaw = components[1]
-			zone = components[2]
-		} else {
-			// `{accountname}.{dnszone}.{component}.storage.azure.net`
-			accountName = components[0]
-			zone = components[1]
-			subDomainTypeRaw = components[2]
+	case dnsZoneDomain:
+		if l := len(components); l != 3 {
+			return nil, fmt.Errorf("expect 3 uri components before the domain suffix %q, got=%d", domainSuffix, l)
 		}
-
-		accountId.AccountName = accountName
-		subDomainType, err := parseSubDomainType(subDomainTypeRaw)
+		accountId.AccountName = components[0]
+		subDomainType, err := parseSubDomainType(components[2])
 		if err != nil {
 			return nil, err
 		}
 		accountId.SubDomainType = *subDomainType
-		accountId.ZoneName = pointer.To(zone)
+		accountId.ZoneName = pointer.To(components[1])
+		return &accountId, nil
+	case edgeZoneDomain:
+		if l := len(components); l != 3 {
+			return nil, fmt.Errorf("expect 3 uri components before the domain suffix %q, got=%d", domainSuffix, l)
+		}
+		accountId.AccountName = components[0]
+		subDomainType, err := parseSubDomainType(components[1])
+		if err != nil {
+			return nil, err
+		}
+		accountId.SubDomainType = *subDomainType
+		accountId.ZoneName = pointer.To(components[2])
 		return &accountId, nil
 	}
 

--- a/storage/2023-11-03/blob/accounts/resource_id_test.go
+++ b/storage/2023-11-03/blob/accounts/resource_id_test.go
@@ -36,7 +36,7 @@ func TestParseAccountIDInDNSZone(t *testing.T) {
 		SubDomainType: BlobSubDomainType,
 		DomainSuffix:  "storage.azure.net",
 	}
-	actual, err := ParseAccountID(input, "storage.azure.net")
+	actual, err := ParseAccountID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -69,7 +69,7 @@ func TestParseAccountIDInEdgeZone(t *testing.T) {
 		SubDomainType: BlobSubDomainType,
 		DomainSuffix:  "edgestorage.azure.net",
 	}
-	actual, err := ParseAccountID(input, "edgestorage.azure.net")
+	actual, err := ParseAccountID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/storage/2023-11-03/blob/blobs/resource_id_test.go
+++ b/storage/2023-11-03/blob/blobs/resource_id_test.go
@@ -98,7 +98,7 @@ func TestParseBlobIDInADNSZone(t *testing.T) {
 		ContainerName: "container1",
 		BlobName:      "blob1.vhd",
 	}
-	actual, err := ParseBlobID(input, "storage.azure.net")
+	actual, err := ParseBlobID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -135,7 +135,7 @@ func TestParseBlobIDInAnEdgeZone(t *testing.T) {
 		ContainerName: "container1",
 		BlobName:      "blob1.vhd",
 	}
-	actual, err := ParseBlobID(input, "edgestorage.azure.net")
+	actual, err := ParseBlobID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/storage/2023-11-03/blob/containers/resource_id_test.go
+++ b/storage/2023-11-03/blob/containers/resource_id_test.go
@@ -54,7 +54,7 @@ func TestParseContainerIDInADNSZone(t *testing.T) {
 		},
 		ContainerName: "container1",
 	}
-	actual, err := ParseContainerID(input, "storage.azure.net")
+	actual, err := ParseContainerID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -87,7 +87,7 @@ func TestParseContainerIDInAnEdgeZone(t *testing.T) {
 		},
 		ContainerName: "container1",
 	}
-	actual, err := ParseContainerID(input, "edgestorage.azure.net")
+	actual, err := ParseContainerID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/storage/2023-11-03/datalakestore/filesystems/resource_id_test.go
+++ b/storage/2023-11-03/datalakestore/filesystems/resource_id_test.go
@@ -54,7 +54,7 @@ func TestParseFileSystemIDInADNSZone(t *testing.T) {
 		},
 		FileSystemName: "fileSystem1",
 	}
-	actual, err := ParseFileSystemID(input, "storage.azure.net")
+	actual, err := ParseFileSystemID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -87,7 +87,7 @@ func TestParseFileSystemIDInAnEdgeZone(t *testing.T) {
 		},
 		FileSystemName: "fileSystem1",
 	}
-	actual, err := ParseFileSystemID(input, "edgestorage.azure.net")
+	actual, err := ParseFileSystemID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/storage/2023-11-03/datalakestore/paths/resource_id_test.go
+++ b/storage/2023-11-03/datalakestore/paths/resource_id_test.go
@@ -51,7 +51,7 @@ func TestParsePathIDInADNSZone(t *testing.T) {
 		FileSystemName: "fileSystem1",
 		Path:           "some/path",
 	}
-	actual, err := ParsePathID(input, "storage.azure.net")
+	actual, err := ParsePathID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -88,7 +88,7 @@ func TestParsePathIDInAnEdgeZone(t *testing.T) {
 		FileSystemName: "fileSystem1",
 		Path:           "some/path",
 	}
-	actual, err := ParsePathID(input, "edgestorage.azure.net")
+	actual, err := ParsePathID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/storage/2023-11-03/file/directories/resource_id_test.go
+++ b/storage/2023-11-03/file/directories/resource_id_test.go
@@ -51,7 +51,7 @@ func TestParseDirectoryIDInADNSZone(t *testing.T) {
 		ShareName:     "share1",
 		DirectoryPath: "path",
 	}
-	actual, err := ParseDirectoryID(input, "storage.azure.net")
+	actual, err := ParseDirectoryID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -88,7 +88,7 @@ func TestParseDirectoryIDInAnEdgeZone(t *testing.T) {
 		ShareName:     "share1",
 		DirectoryPath: "some/path",
 	}
-	actual, err := ParseDirectoryID(input, "edgestorage.azure.net")
+	actual, err := ParseDirectoryID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/storage/2023-11-03/file/files/resource_id_test.go
+++ b/storage/2023-11-03/file/files/resource_id_test.go
@@ -56,7 +56,7 @@ func TestParseFileIDInADNSZone(t *testing.T) {
 		DirectoryPath: "path",
 		FileName:      "file.txt",
 	}
-	actual, err := ParseFileID(input, "storage.azure.net")
+	actual, err := ParseFileID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -97,7 +97,7 @@ func TestParseFileIDInAnEdgeZone(t *testing.T) {
 		DirectoryPath: "some/path",
 		FileName:      "file.txt",
 	}
-	actual, err := ParseFileID(input, "edgestorage.azure.net")
+	actual, err := ParseFileID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/storage/2023-11-03/file/shares/resource_id_test.go
+++ b/storage/2023-11-03/file/shares/resource_id_test.go
@@ -54,7 +54,7 @@ func TestParseShareIDInADNSZone(t *testing.T) {
 		},
 		ShareName: "share1",
 	}
-	actual, err := ParseShareID(input, "storage.azure.net")
+	actual, err := ParseShareID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -87,7 +87,7 @@ func TestParseShareIDInAnEdgeZone(t *testing.T) {
 		},
 		ShareName: "share1",
 	}
-	actual, err := ParseShareID(input, "edgestorage.azure.net")
+	actual, err := ParseShareID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/storage/2023-11-03/queue/queues/resource_id_test.go
+++ b/storage/2023-11-03/queue/queues/resource_id_test.go
@@ -54,7 +54,7 @@ func TestParseQueueIDInADNSZone(t *testing.T) {
 		},
 		QueueName: "queue1",
 	}
-	actual, err := ParseQueueID(input, "storage.azure.net")
+	actual, err := ParseQueueID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -87,7 +87,7 @@ func TestParseQueueIDInAnEdgeZone(t *testing.T) {
 		},
 		QueueName: "queue1",
 	}
-	actual, err := ParseQueueID(input, "edgestorage.azure.net")
+	actual, err := ParseQueueID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/storage/2023-11-03/table/entities/resource_id_test.go
+++ b/storage/2023-11-03/table/entities/resource_id_test.go
@@ -56,7 +56,7 @@ func TestParseEntityIDInADNSZone(t *testing.T) {
 		PartitionKey: "partition1",
 		RowKey:       "row1",
 	}
-	actual, err := ParseEntityID(input, "storage.azure.net")
+	actual, err := ParseEntityID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -97,7 +97,7 @@ func TestParseEntityIDInAnEdgeZone(t *testing.T) {
 		PartitionKey: "partition1",
 		RowKey:       "row1",
 	}
-	actual, err := ParseEntityID(input, "edgestorage.azure.net")
+	actual, err := ParseEntityID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}

--- a/storage/2023-11-03/table/tables/resource_id_test.go
+++ b/storage/2023-11-03/table/tables/resource_id_test.go
@@ -82,7 +82,7 @@ func TestParseTableIDInADNSZone(t *testing.T) {
 		},
 		TableName: "table1",
 	}
-	actual, err := ParseTableID(input, "storage.azure.net")
+	actual, err := ParseTableID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}
@@ -115,7 +115,7 @@ func TestParseTableIDInAnEdgeZone(t *testing.T) {
 		},
 		TableName: "table1",
 	}
-	actual, err := ParseTableID(input, "edgestorage.azure.net")
+	actual, err := ParseTableID(input, "core.windows.net")
 	if err != nil {
 		t.Fatalf(err.Error())
 	}


### PR DESCRIPTION
Previously the `accounts.ParseAccountID()` takes different domain suffixes:
- regular domain suffix (cloud dependent)
- dns zone domain suffix (cloud independent)
- edge zone domain suffix (cloud independent)

So far in the azurerm provider codebase, every call to this function passes the regular domain suffix only:

```
internal/services/arckubernetes/arc_kubernetes_flux_configuration_resource.go|975 col 29-43| accountId, err := accounts.ParseAccountID(pointer.From(input.Url), storageDomainSuffix)
internal/services/containers/kubernetes_flux_configuration_resource.go|1131 col 29-43| accountId, err := accounts.ParseAccountID(pointer.From(input.Url), storageDomainSuffix)
internal/services/storage/storage_blob_data_source.go|109 col 29-43| accountId, err := accounts.ParseAccountID(*blobEndpoint, storageClient.StorageDomainSuffix)
internal/services/storage/storage_container_data_source.go|134 col 31-45| accountId, err := accounts.ParseAccountID(*endpoint, storageClient.StorageDomainSuffix)
internal/services/storage/storage_container_resource.go|215 col 31-45| accountId, err := accounts.ParseAccountID(*endpoint, storageClient.StorageDomainSuffix)
internal/services/storage/storage_containers_data_source.go|118 col 31-45| accountId, err := accounts.ParseAccountID(*endpoint, metadata.Client.Storage.StorageDomainSuffix)
internal/services/storage/storage_data_lake_gen2_filesystem_resource.go|184 col 29-43| accountId, err := accounts.ParseAccountID(*endpoint, storageClient.StorageDomainSuffix)
internal/services/storage/storage_data_lake_gen2_path_resource.go|194 col 29-43| accountId, err := accounts.ParseAccountID(*endpoint, storageClient.StorageDomainSuffix)
internal/services/storage/storage_queue_data_source.go|110 col 31-45| accountId, err := accounts.ParseAccountID(pointer.From(endpoint), storageClient.StorageDomainSuffix)
internal/services/storage/storage_queue_data_source.go|175 col 31-45| accountDpId, err := accounts.ParseAccountID(*endpoint, meta.(*clients.Client).Storage.StorageDomainSuffix)
internal/services/storage/storage_queue_resource.go|173 col 31-45| accountId, err := accounts.ParseAccountID(*endpoint, storageClient.StorageDomainSuffix)
internal/services/storage/storage_queue_resource.go|402 col 31-45| accountDpId, err := accounts.ParseAccountID(*endpoint, meta.(*clients.Client).Storage.StorageDomainSuffix)
internal/services/storage/storage_share_data_source.go|147 col 31-45| accountId, err := accounts.ParseAccountID(*endpoint, storageClient.StorageDomainSuffix)
internal/services/storage/storage_share_directory_resource.go|132 col 29-43| accountId, err := accounts.ParseAccountID(storageShareId.ID(), storageClient.StorageDomainSuffix)
internal/services/storage/storage_share_directory_resource.go|244 col 29-43| accountId, err := accounts.ParseAccountID(*endpoint, storageClient.StorageDomainSuffix)
internal/services/storage/storage_share_file_resource.go|169 col 29-43| accountId, err := accounts.ParseAccountID(storageShareId.ID(), storageClient.StorageDomainSuffix)
internal/services/storage/storage_share_resource.go|243 col 31-45| accountId, err := accounts.ParseAccountID(*endpoint, storageClient.StorageDomainSuffix)
internal/services/storage/storage_share_resource.go|475 col 29-43| accountId, err := accounts.ParseAccountID(*endpoint, meta.(*clients.Client).Storage.StorageDomainSuffix)
internal/services/storage/storage_table_data_source.go|141 col 31-45| accountId, err := accounts.ParseAccountID(*endpoint, storageClient.StorageDomainSuffix)
internal/services/storage/storage_table_entity_data_source.go|101 col 29-43| accountId, err := accounts.ParseAccountID(*endpoint, storageClient.StorageDomainSuffix)
internal/services/storage/storage_table_entity_resource.go|108 col 29-43| accountId, err := accounts.ParseAccountID(storageTableId.ID(), storageClient.StorageDomainSuffix)
internal/services/storage/storage_table_resource.go|143 col 29-43| accountId, err := accounts.ParseAccountID(*endpoint, storageClient.StorageDomainSuffix)
vendor/github.com/jackofallops/giovanni/storage/2023-11-03/blob/accounts/resource_id.go|79 col 6-20| func ParseAccountID(input, regularDomainSuffix string) (*AccountId, error) {
```

This PR changes the semantic of this function to always only take the cloud dependent regular domain suffix as the input variable, which varies per different cloud. While hard code the cloud independent domain suffixes in the implementation.

This solves the issue reported here: https://github.com/hashicorp/terraform-provider-azurerm/issues/25713.

Also, once this PR gets merged, I'll need to update https://github.com/jackofallops/giovanni/pull/3.